### PR TITLE
toImageData() factored into own method with example

### DIFF
--- a/src/texgen.js
+++ b/src/texgen.js
@@ -66,19 +66,14 @@ TG.Texture.prototype = {
 		return this.pass( program, '/' );
 
 	},
-
-	toCanvas: function () {
+  
+  toImageData: function(context) {
 
 		var width = this.width;
 		var height = this.height;
 
 		var array = this.array;
 
-		var canvas = document.createElement( 'canvas' );
-		canvas.width = width;
-		canvas.height = height;
-
-		var context = canvas.getContext( '2d' );
 		var imagedata = context.createImageData( width, height );
 		var data = imagedata.data;
 
@@ -90,6 +85,19 @@ TG.Texture.prototype = {
 			data[ i + 3 ] = 255;
 
 		}
+
+    return imagedata;
+
+  },
+
+	toCanvas: function () {
+
+		var canvas = document.createElement( 'canvas' );
+		canvas.width = this.width;
+		canvas.height = this.height;
+
+		var context = canvas.getContext( '2d' );
+		var imagedata = this.toImageData(context);
 
 		context.putImageData( imagedata, 0, 0 );
 

--- a/waves.html
+++ b/waves.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>texgen.js</title>
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<style>
+			body {
+				margin: 20px;
+        background: #111;
+			}
+			canvas {
+				margin-right: 20px;
+			}
+		</style>
+	</head>
+	<body>
+		<script src="src/texgen.js"></script>
+		<script>
+    var size = 350;
+
+    var canvas = document.createElement("canvas");
+    canvas.height = size;
+    canvas.width = size * 3;
+	  document.body.appendChild( canvas );
+    var context = canvas.getContext("2d");
+
+    loop(step);
+
+    var i = 0;
+    function step() {
+      i++;
+
+			var texture = new TG.Texture( size, size )
+				.add( new TG.SinX().frequency( 0.05+i/1000 ) )
+				.mul( new TG.SinX().frequency( 0.08-i/2000 ) )
+				.add( new TG.SinY().frequency( 0.05-i/1000 ) )
+				.mul( new TG.SinY().frequency( 0.08+i/2000 ) )
+				.div( new TG.Number().color( 1, 2, 1 ) )
+				.add( new TG.SinX().frequency( 0.003 ).color( 0.5, 0, 0 ) )
+				.toImageData(context);
+
+      context.putImageData( texture, 0, 0 );
+
+			//
+
+			var texture = new TG.Texture( size, size )
+				.add( new TG.SinX().frequency( 0.066 + 0.05*Math.sin(i/100) ) )
+				.add( new TG.SinY().frequency( 0.066 + 0.05*Math.sin(i/100) ) )
+				.mul( new TG.SinX().offset( 32 ).frequency( 0.044 + 0.09*Math.sin(i/100) ).color( 2, 2, 2 ) )
+				.mul( new TG.SinY().offset( 16 ).frequency( 0.044 + 0.09*Math.sin(i/100) ).color( 2, 2, 2 ) )
+				.sub( new TG.Number().color( 0.5, 2, 4 ) )
+				.toImageData(context);
+
+      context.putImageData( texture, size, 0 );
+
+			//
+
+			var texture = new TG.Texture( size, size )
+				.add( new TG.SinX().frequency( 0.004 + 0.002*Math.sin(i/100)) )
+				.mul( new TG.SinY().frequency( 0.004  + 0.002*Math.sin(i/100)) )
+				.mul( new TG.SinX().offset( 32 ).frequency( 0.04 + 0.02*Math.sin(i/100) ) )
+				.mul( new TG.SinY().offset( 32 ).frequency( 0.04 + 0.02*Math.sin(i/100) ) )
+				.div( new TG.SinX().frequency( 0.02 ).color( 5, 4, 3 ) )
+				.mul( new TG.SinX().frequency( 0.003 ).color( 0.5, 0, 0 ) )
+				.add( new TG.Noise().color( 0.1, 0, 0 ) )
+				.add( new TG.Noise().color( 0, 0.1, 0 ) )
+				.add( new TG.Noise().color( 0, 0, 0.1 ) )
+				.toImageData(context);
+
+      context.putImageData( texture, size * 2, 0 );
+    };
+
+    function loop(f) {
+      f();
+      requestAnimationFrame(function() {
+        loop(f);
+      });
+    };
+
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
This lets one use a persistent canvas, rather than destroying and replacing the old canvas each step of an animation.

Example 3 animated textures.
