### PR TITLE
Fixed sinedistort, twirl and transform for RGB and invert TG.Circle generator

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -172,7 +172,7 @@
 			//
 
 			var texture = new TG.Texture( 256, 256 )
-			.add( new TG.Circle().position( 128, 128 ).radius( 64 ).delta( 60 ) )
+			.add( new TG.Circle().position( 128, 128 ).radius( 64 ).delta( 60 ).color( 1, 0.25, 0.25 ) )
 			.set( new TG.Pixelate().size( 8, 8 ) )
 			.toCanvas();
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -181,7 +181,7 @@
 			//
 
 			var texture = new TG.Texture( 256, 256 )
-				.add( new TG.CheckerBoard() )
+				.add( new TG.CheckerBoard().color( 1, 1, 0 ) )
 				.set( new TG.Transform().offset( 10, 20 ).angle( 23 ).scale( 2, 0.5 ) )
 				.toCanvas();
 

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -422,8 +422,9 @@ TG.Transform = function () {
 
 						's += ' + offset[ 0 ] + ' + width /2;',
 						't += ' + offset[ 1 ] + ' + height /2;',
-						'var value = TG.Utils.getPixelBilinear( src.array, s, t, 0, width, height );',
-						'color.setRGB( value, value, value );'
+
+						'color.set( src.getPixelNearest( s, t ) );',
+						
 					].join( '\n' );
 				}
 		} );

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -340,10 +340,9 @@ TG.SineDistort = function () {
 		},
 		getSource: function () {
 			return [
-				'var sx = Math.sin(' + sines[ 0 ] / 100 + ' * y + ' + offset[ 0 ] + ') * ' + amplitude[ 0 ] + ' + x;',
-				'var sy = Math.sin(' + sines[ 1 ] / 100 + ' * x + ' + offset[ 1 ] + ') * ' + amplitude[ 1 ] + ' + y;',
-				'var value = TG.Utils.getPixelBilinear( src.array, sx, sy, 0, width, height );',
-				'color.setRGB( value, value, value );'
+				'var s = Math.sin(' + sines[ 0 ] / 100 + ' * y + ' + offset[ 0 ] + ') * ' + amplitude[ 0 ] + ' + x;',
+				'var t = Math.sin(' + sines[ 1 ] / 100 + ' * x + ' + offset[ 1 ] + ') * ' + amplitude[ 1 ] + ' + y;',
+				'color.set( src.getPixelNearest( s, t ) );',
 			].join( '\n' );
 		}
 	} );

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -308,9 +308,11 @@ TG.Circle = function () {
 		},
 		getSource: function () {
 			return [
+				
 				'var dist = TG.Utils.distance( x, y, ' + position[ 0 ] + ',' + position[ 1 ] + ');',
-				'var value = TG.Utils.smoothStep( ' + radius + ' - ' + delta + ', ' + radius + ', dist );',
+				'var value = 1 - TG.Utils.smoothStep( ' + radius + ' - ' + delta + ', ' + radius + ', dist );',
 				'color.setRGB( value, value, value );'
+
 			].join('\n');
 		}
 	} );
@@ -424,7 +426,7 @@ TG.Transform = function () {
 						't += ' + offset[ 1 ] + ' + height /2;',
 
 						'color.set( src.getPixelNearest( s, t ) );',
-						
+
 					].join( '\n' );
 				}
 		} );
@@ -445,8 +447,8 @@ TG.Pixelate = function () {
 				'var s = ' + size[ 0 ] + ' * Math.floor(x/' + size[ 0 ] + ');',
 				'var t = ' + size[ 1 ] + ' * Math.floor(y/' + size[ 1 ] + ');',
 
-				'var value = src.getPixelNearest( s, t );',
-				'color.set( value );'
+				'color.set( src.getPixelNearest( s, t ) );'
+
 			].join( '\n' );
 		}
 	} );

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -377,15 +377,15 @@ TG.Twirl = function () {
 					'dist = Math.pow('+ radius +' - dist, 2) / ' + radius + ';',
 
 					'var angle = 2.0 * Math.PI * (dist / (' + radius + ' / ' + strength + '));',
-					'xpos = (((x - ' + position[ 0 ] + ') * Math.cos(angle)) - ((y - ' + position[ 0 ] + ') * Math.sin(angle)) + ' + position[ 0 ] + ' + 0.5);',
-					'ypos = (((y - ' + position[ 1 ] + ') * Math.cos(angle)) + ((x - ' + position[ 1 ] + ') * Math.sin(angle)) + ' + position[ 1 ] + ' + 0.5);',
+					's = (((x - ' + position[ 0 ] + ') * Math.cos(angle)) - ((y - ' + position[ 0 ] + ') * Math.sin(angle)) + ' + position[ 0 ] + ' + 0.5);',
+					't = (((y - ' + position[ 1 ] + ') * Math.cos(angle)) + ((x - ' + position[ 1 ] + ') * Math.sin(angle)) + ' + position[ 1 ] + ' + 0.5);',
 				'} else {',
-					'xpos = x;',
-					'ypos = y;',
+					's = x;',
+					't = y;',
 				'}',
 
-				'var value = TG.Utils.getPixelBilinear( src.array, xpos, ypos, 0, width, height );',
-				'color.setRGB( value, value, value );'
+				'color.set( src.getPixelNearest( s, t ) );',
+
 			].join( '\n' );
 		}
 	} );


### PR DESCRIPTION
Right now I've used `getPixelNearest`. They works now on rgb. 
I've used s,t as glsl convention, instead of x0,x1, xpos, ypos, etc.
TG.Circle will now generate the circle on 1.0 instead of 0.0
