### PR TITLE
Added FractalNoise

### DIFF
--- a/examples/noise.html
+++ b/examples/noise.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+
+<html>
+	<head>
+		<style type="text/css">
+			@import url(http://fonts.googleapis.com/css?family=Lato:400);
+
+			body {
+				background-color: rgb(16, 18, 23);
+				color: rgb(200, 228, 255);
+				font-family: Lato, sans-serif;
+				text-align: center;
+			}
+
+			#noise > div {
+				margin: 20px;
+				display: inline-block;
+			}
+
+			canvas {
+				border: 1px solid #202227;
+				margin: auto;
+			}
+
+			p {
+				color: rgb(198, 222, 255);
+				background: rgba(211, 255, 247, 0.1);
+
+				margin: 5px 0 0;
+				padding: 10px;
+				min-height: 1em;
+			}
+
+			h1 {
+				font-size: 40px;
+			}
+
+		</style>
+	</head>
+	<body>
+		<h1>Fractal Noise</h1>
+		<h2 id="render">Rendering page content... </h2>
+		<h5 id="hint"></h5>
+
+		<div id="noise"></div>
+
+		<script type="text/javascript" src="../src/TexGen.js"></script>
+		<script>
+			TG.Texture.prototype.addToPage = function (desc) {
+				var div = document.createElement("div");
+				var p = document.createElement("p");
+
+				p.innerHTML = desc;
+
+				div.appendChild(this.toCanvas() );
+				div.appendChild(p);
+
+				noise.appendChild(div);
+
+				return div;
+			}
+
+			function render() {
+				var noise = document.getElementById("noise");
+				var pageStatus = document.getElementById("render");
+				var hint = document.getElementById("hint");
+
+				var seed = Date.now();
+
+			//---------------------------------------------------------
+
+				new TG.Texture(200, 200)
+					.set(new TG.FractalNoise().seed(seed).baseFrequency(20).octaves(1).amplitude(0.5) )
+					.addToPage("Base Frequency");
+
+				new TG.Texture(200, 200)
+					.set(new TG.FractalNoise().seed(seed * 2).baseFrequency(10).octaves(1).amplitude(0.25) )
+					.addToPage("+ Octave");
+
+				new TG.Texture(200, 200)
+					.set(new TG.FractalNoise().seed(seed * 3).baseFrequency(5).octaves(1).amplitude(0.125) )
+					.addToPage("+ Octave");
+
+				var spacing = new TG.Texture(200, 200)
+					.set(new TG.FractalNoise().seed(seed).baseFrequency(20).octaves(3).step(2).amplitude(0.5).persistence(0.5) )
+					.addToPage("= Fractal Noise");
+
+				spacing.style.margin = "20px 20px 80px";
+
+				line = document.createElement("br");
+				noise.appendChild(line);
+
+			//---------------------------------------------------------
+
+				var amp = [0.32, 0.42, 0.32, 0.42];
+				var prs = [0.78, 0.78, 0.68, 0.68];
+
+				for (var i = 0; i < 4; i++) {
+					new TG.Texture(200, 200)
+						.set(new TG.FractalNoise().seed(seed).baseFrequency(200).octaves(8).step(2).amplitude(amp[i]).persistence(prs[i]) )
+						.addToPage("No Interpolation<br/>Amplitude: " + amp[i] + "<br/>Persistence: " + prs[i]);
+				}
+
+				var line = document.createElement("br");
+				noise.appendChild(line);
+
+				for (var i = 0; i < 4; i++) {
+					new TG.Texture(200, 200)
+						.set(new TG.FractalNoise().seed(seed).baseFrequency(200).octaves(8).step(2).amplitude(amp[i]).persistence(prs[i]).interpolation(1) )
+						.addToPage("Linear Interpolation<br/>Amplitude: " + amp[i] + "<br/>Persistence: " + prs[i]);
+				}
+
+				line = document.createElement("br");
+				noise.appendChild(line);
+
+				for (var i = 0; i < 4; i++) {
+					new TG.Texture(200, 200)
+						.set(new TG.FractalNoise().seed(seed).baseFrequency(200).octaves(8).step(2).amplitude(amp[i]).persistence(prs[i]).interpolation(2) )
+						.addToPage("Spline Interpolation<br/>Amplitude: " + amp[i] + "<br/>Persistence: " + prs[i]);
+				}
+
+				line = document.createElement("br");
+				noise.appendChild(line);
+
+			//---------------------------------------------------------
+
+				new TG.Texture(25, 25)
+					.set(new TG.FractalNoise().seed(seed).baseFrequency(200).octaves(8).step(2) )
+					.addToPage("25px &#8594;");
+
+				new TG.Texture(50, 50)
+					.set(new TG.FractalNoise().seed(seed).baseFrequency(200).octaves(8).step(2) )
+					.add(new TG.Rect().size(0, 25).position(25, 0).tint(10, -10, -10) )
+					.add(new TG.Rect().size(25, 0).position(0, 25).tint(10, -10, -10) )
+					.addToPage("50px &#8594;");
+
+				new TG.Texture(100, 100)
+					.set(new TG.FractalNoise().seed(seed).baseFrequency(200).octaves(8).step(2) )
+					.add(new TG.Rect().size(0, 50).position(50, 0).tint(10, -10, -10) )
+					.add(new TG.Rect().size(50, 0).position(0, 50).tint(10, -10, -10) )
+					.addToPage("100px &#8594;");
+
+				spacing = new TG.Texture(200, 200)
+					.set(new TG.FractalNoise().seed(seed).baseFrequency(200).octaves(8).step(2) )
+					.add(new TG.Rect().size(0, 100).position(100, 0).tint(10, -10, -10) )
+					.add(new TG.Rect().size(100, 0).position(0, 100).tint(10, -10, -10) )
+					.addToPage("200px <br/> (width and height independent)");
+
+				spacing.style.margin = "80px 20px 20px";
+
+				line = document.createElement("br");
+				noise.appendChild(line);
+
+				new TG.Texture(100, 100)
+					.set(new TG.Noise().seed(seed) )
+					.addToPage("100px &#8594;");
+
+				spacing = new TG.Texture(200, 200)
+					.set(new TG.Noise().seed(seed) )
+					.add(new TG.Rect().size(0, 100).position(100, 0).tint(10, -10, -10) )
+					.add(new TG.Rect().size(100, 0).position(0, 100).tint(10, -10, -10) )
+					.addToPage("200px <br/> (also works with regular noise)");
+
+				spacing.style.margin = "20px 20px 80px";
+
+				line = document.createElement("br");
+				noise.appendChild(line);
+
+			//---------------------------------------------------------
+
+				size = 256;
+
+				new TG.Texture(size, size)
+					.set(new TG.FractalNoise().baseFrequency(20).persistence(0.75).amplitude(0.4).interpolation(2).tint(0.75, 0.95, 1) )
+					.add(new TG.FractalNoise().baseFrequency(4).octaves(3).interpolation(1).tint(0.25, 0.35, 0.85) )
+					.sub(new TG.Twirl().radius(size * 3).strength(1.5).position(size/2, size/2) )
+					.mul(new TG.Circle().radius(size * 1.1).position(size/2, size/2).delta(size) )
+					.addToPage("Example 1");
+
+				new TG.Texture(size, size)
+					.set(new TG.FractalNoise().baseFrequency(20).persistence(0.75).amplitude(0.4).interpolation(0).tint(0.7, 0.9, 0.95) )
+					.add(new TG.FractalNoise().baseFrequency(4).octaves(3).interpolation(0).tint(0.2, 0.3, 0.8) )
+					.sub(new TG.Twirl().radius(size * 3).strength(1.5).position(size/2, size/2) )
+					.mul(new TG.Circle().radius(size * 1.1).position(size/2, size/2).delta(size) )
+					.addToPage("Example 1 (no interpolation)");
+
+				line = document.createElement("br");
+				noise.appendChild(line);
+
+				new TG.Texture(size, size)
+					.set(new TG.FractalNoise().baseFrequency(64).octaves(6).step(2).interpolation(2) )
+					.sub(new TG.Noise().tint(0, 0.1, 0) )
+					.min(new TG.Number().tint(0, 0.6, 0) )
+					.sub(new TG.Number().tint(0, 0.5, 0) )
+					.mul(new TG.Number().tint(0, 5, 0) )
+					.sub(new TG.SineDistort().sines(2, 2).amplitude(8, 8).tint(0, 0.75, 0) )
+					.add(new TG.Number().tint(0.06, 0, 0.085) )
+					.addToPage("Example 2");
+
+				new TG.Texture(size, size)
+					.set(new TG.FractalNoise().baseFrequency(128).octaves(6).step(2).interpolation(2) )
+					.sub(new TG.Noise().tint(0, 0.1, 0) )
+					.min(new TG.Number().tint(0, 0.63, 0) )
+					.sub(new TG.Number().tint(0, 0.53, 0) )
+					.mul(new TG.Number().tint(0, 6, 0) )
+					.sub(new TG.SineDistort().sines(2, 2).amplitude(4, 4).tint(0, 0.75, 0) )
+					.add(new TG.Number().tint(0.065, 0, 0.095) )
+					.addToPage("Example 2 (less distortion)");
+
+				line = document.createElement("br");
+				noise.appendChild(line);
+
+				new TG.Texture(size, size)
+					.set(new TG.FractalNoise().baseFrequency(64).octaves(6).step(2).interpolation(2).tint(1, 0.17, 0.32) )
+					.sub(new TG.Noise().tint(0.2, 0.08, 0.03) )
+					.mul(new TG.XOR().tint(1.5, 1.62, 1.69) )
+					.addToPage("Example 3 (xor)");
+
+				new TG.Texture(size, size)
+					.set(new TG.FractalNoise().baseFrequency(64).octaves(6).step(2).interpolation(2).tint(1, 0.17, 0.32) )
+					.sub(new TG.Noise().tint(0.2, 0.08, 0.03) )
+					.mul(new TG.FractalNoise().octaves(2).baseFrequency(size/4).step(1.7).interpolation(0).amplitude(0.6).persistence(0.6).tint(1.5, 1.62, 1.69) )
+					.addToPage("Example 3 (noise)");
+
+				pageStatus.innerHTML = "Seed: " + seed;
+				hint.innerHTML = "(reload page for new pattern)";
+			};
+
+			setTimeout(render, 500);
+		</script>
+	</body>
+</html>

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -738,7 +738,7 @@ TG.ColorInterpolatorMethod = {
 TG.ColorInterpolator = function( method ) {
 
 	this.points = [];
-	this.interpolation = ( method == 'undefined' ) ? TG.ColorInterpolatorMethod.LINEAR : method;
+	this.interpolation = ( typeof( method ) == 'undefined' ) ? TG.ColorInterpolatorMethod.LINEAR : method;
 	this.repeat = false;
 
 	return this;

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -254,11 +254,111 @@ TG.Noise = function () {
 		},
 		getSource: function () {
 			return [
-				'params.seed = ( ( params.seed * 48271 ) + 777777 ) % 4294967296;',
-				'var value = Math.abs( params.seed / 4294967296 )',
+				'var value = TG.Utils.hashRNG( params.seed, x, y );',
 				'color[ 0 ] = value;',
 				'color[ 1 ] = value;',
 				'color[ 2 ] = value;'
+			].join('\n');
+		}
+	} );
+
+};
+
+TG.FractalNoise = function () {
+
+	var params = {
+		interpolator: new TG.ColorInterpolator( TG.ColorInterpolatorMethod.STEP ),
+		seed: Date.now(),
+		baseFrequency: 0.03125,
+		amplitude: 0.4,
+		persistence: 0.72,
+		octaves: 4,
+		step: 4
+	};
+
+	return new TG.Program( {
+		seed: function ( value ) {
+			params.seed = value;
+			return this;
+		},
+		baseFrequency: function ( value ) {
+			params.baseFrequency = 1 / value;
+			return this;
+		},
+		amplitude: function ( value ) {
+			params.amplitude = value;
+			return this;
+		},
+		persistence: function ( value ) {
+			params.persistence = value;
+			return this;
+		},
+		octaves: function ( value ) {
+			params.octaves = Math.max( 1, value );
+			return this;
+		},
+		step: function ( value ) {
+			params.step = Math.max( 1, value );
+			return this;
+		},
+		interpolation: function ( value ) {
+			params.interpolator.setInterpolation( value );
+			return this;
+		},
+		getParams: function () {
+			return params;
+		},
+		getSource: function () {
+			return [
+				'var value = 0;',
+				'var amp = params.amplitude;',
+				'var freq = params.baseFrequency;',
+				'var x1, y1, dx, dy;',
+				'var v1, v2, v3, v4;',
+				'var i1, i2;',
+
+				'for ( var j = 1; j <= params.octaves; j++ ) {',
+					'x1 = Math.floor( x * freq ), y1 = Math.floor( y * freq );',
+
+					'if ( params.interpolator.interpolation == TG.ColorInterpolatorMethod.STEP ) {',
+						'value += TG.Utils.hashRNG( params.seed * j, x1, y1 ) * amp;',
+					'} else {',
+						'dx = ( x * freq ) - x1, dy = ( y * freq ) - y1;',
+
+						'v1 = TG.Utils.hashRNG( params.seed * j, x1    , y1     );',
+						'v2 = TG.Utils.hashRNG( params.seed * j, x1 + 1, y1     );',
+						'v3 = TG.Utils.hashRNG( params.seed * j, x1    , y1 + 1 );',
+						'v4 = TG.Utils.hashRNG( params.seed * j, x1 + 1, y1 + 1 );',
+
+						'params.interpolator.set( [',
+							'{ pos: 0, color: [ v1 ] },',
+							'{ pos: 1, color: [ v2 ] }',
+						'] );',
+
+						'i1 = params.interpolator.getColorAt( dx );',
+
+						'params.interpolator.set( [',
+							'{ pos: 0, color: [ v3 ] },',
+							'{ pos: 1, color: [ v4 ] }',
+						'] );',
+
+						'i2 = params.interpolator.getColorAt( dx );',
+
+						'params.interpolator.set( [',
+							'{ pos: 0, color: [ i1[ 0 ] ] },',
+							'{ pos: 1, color: [ i2[ 0 ] ] }',
+						'] );',
+
+						'value += params.interpolator.getColorAt( dy )[ 0 ] * amp;',
+					'}',
+
+					'freq *= params.step;',
+					'amp *= params.persistence;',
+				'}',
+
+				'color[ 0 ] = value;',
+				'color[ 1 ] = value;',
+				'color[ 2 ] = value;',
 			].join('\n');
 		}
 	} );
@@ -439,11 +539,11 @@ TG.Twirl = function () {
 					'dist = Math.pow(params.radius - dist, 2) / params.radius;',
 
 					'var angle = 2.0 * Math.PI * (dist / (params.radius / params.strength));',
-					's = (((x - params.position[ 0 ]) * Math.cos(angle)) - ((y - params.position[ 0 ]) * Math.sin(angle)) + params.position[ 0 ] + 0.5);',
-					't = (((y - params.position[ 1 ]) * Math.cos(angle)) + ((x - params.position[ 1 ]) * Math.sin(angle)) + params.position[ 1 ] + 0.5);',
+					'var s = (((x - params.position[ 0 ]) * Math.cos(angle)) - ((y - params.position[ 0 ]) * Math.sin(angle)) + params.position[ 0 ] + 0.5);',
+					'var t = (((y - params.position[ 1 ]) * Math.cos(angle)) + ((x - params.position[ 1 ]) * Math.sin(angle)) + params.position[ 1 ] + 0.5);',
 				'} else {',
-					's = x;',
-					't = y;',
+					'var s = x;',
+					'var t = y;',
 				'}',
 
 				'color.set( src.getPixelBilinear( s, t ) );',
@@ -635,10 +735,10 @@ TG.ColorInterpolatorMethod = {
 
 // points must be a set pair (point, color):
 // [{ pos0: [r,g,b,a] } , ..., { posN: [r,g,b,a] } ] posX from 0..1
-TG.ColorInterpolator = function( ) {
+TG.ColorInterpolator = function( method ) {
 
 	this.points = [];
-	this.interpolation = TG.ColorInterpolator.SPLINE;
+	this.interpolation = ( method == 'undefined' ) ? TG.ColorInterpolatorMethod.LINEAR : method;
 	this.repeat = false;
 
 	return this;
@@ -731,7 +831,7 @@ TG.ColorInterpolator.prototype = {
 TG.RadialGradient = function () {
 
 	var params = {
-		gradient: new TG.ColorInterpolator( TG.ColorInterpolator.LINEAR ),
+		gradient: new TG.ColorInterpolator( TG.ColorInterpolatorMethod.LINEAR ),
 		radius: 255,
 		center: [ 128, 128 ],
 	};
@@ -775,7 +875,7 @@ TG.RadialGradient = function () {
 TG.LinearGradient = function () {
 
 	var params = {
-		gradient: new TG.ColorInterpolator( TG.ColorInterpolator.LINEAR )
+		gradient: new TG.ColorInterpolator( TG.ColorInterpolatorMethod.LINEAR )
 	};
 
 	return new TG.Program( {
@@ -847,6 +947,20 @@ TG.Utils = {
 
 		return deg * Math.PI / 180;
 
+	},
+
+	hashRNG: function ( seed, x, y ) {
+		seed = ( Math.abs( seed % 2147483648 ) == 0 ) ? 1 : seed;
+
+		var a = ( ( seed * ( x + 1 ) * 777 ) ^ ( seed * ( y + 1 ) * 123 ) ) % 2147483647;
+		a = (a ^ 61) ^ (a >> 16);
+		a = a + (a << 3);
+		a = a ^ (a >> 4);
+		a = a * 0x27d4eb2d;
+		a = a ^ (a >> 15);
+		a = a / 2147483647;
+
+		return a;
 	}
 
 };


### PR DESCRIPTION
I added a new type of noise: fractal noise.

Fractal noise is based on layers (or "octaves") of regular noise being added on top of each other while reducing the strength.

Here is what it looks like:

![Interpolated](https://cloud.githubusercontent.com/assets/10934467/6454802/feb04e72-c14c-11e4-99d8-01fa1822af53.png) ![No interpolation](https://cloud.githubusercontent.com/assets/10934467/6454801/feaee802-c14c-11e4-913e-9593e931e41f.png)
(left with interpolation, right without)

Also had to change the RNG - yet again - to a hashing algorithm that generates numbers based on coordinates, which is required for fractal noise.

I've provided an example page for this as well.

I'm sorry if I'm being intrusive and a bit overzealous. I don't really know if it's okay if I just barge in and add some stuff, but I find this project really interesting and I have some ideas that I think would fit this very nicely. I guess I'm just not really sure how this github thing works.
