### PR TITLE
Gradient map

### DIFF
--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -623,11 +623,11 @@ TG.Pixelate = function () {
 };
 
 TG.GradientMap = function () {
-	
+
 	var params = {
 		gradient: new TG.ColorInterpolator( TG.ColorInterpolatorMethod.LINEAR )
 	};
-	
+
 	return new TG.Program( {
 		repeat: function ( value ) {
 			params.gradient.setRepeat( value );
@@ -647,18 +647,18 @@ TG.GradientMap = function () {
 		getSource: function () {
 			return [
 				'var v = src.getPixelNearest( x, y );',
-				
+
 				'var r = params.gradient.getColorAt( v[ 0 ] )[ 0 ];',
 				'var g = params.gradient.getColorAt( v[ 1 ] )[ 1 ];',
 				'var b = params.gradient.getColorAt( v[ 2 ] )[ 2 ];',
-				
+
 				'color[ 0 ] = r;',
 				'color[ 1 ] = g;',
 				'color[ 2 ] = b;'
 			].join('\n');
 		}
 	} );
-	
+
 };
 
 // Buffer
@@ -793,10 +793,10 @@ TG.ColorInterpolator.prototype = {
 		this.points.sort( function( a, b ) {
 			return a.pos - b.pos;
 		});
-		
+
 		this.low = this.points[ 0 ].pos;
 		this.high = this.points[ this.points.length - 1 ].pos;
-		
+
 		return this;
 
 	},
@@ -807,10 +807,10 @@ TG.ColorInterpolator.prototype = {
 		this.points.sort( function( a, b ) {
 			return a.pos - b.pos;
 		});
-		
+
 		this.low = this.points[ 0 ].pos;
 		this.high = this.points[ this.points.length - 1 ].pos;
-		
+
 		return this;
 
 	},
@@ -833,7 +833,7 @@ TG.ColorInterpolator.prototype = {
 
 		if ( pos > this.high )
 			pos = this.repeat ? pos % this.high : this.high;
-			
+
 		if ( pos < this.low )
 			pos = this.repeat ? pos % this.low : this.low;
 


### PR DESCRIPTION
The gradient map filter assigns colors from a gradient based on the source value.
So, if the source pixel has a value of 0.2, it gets set to the color of the gradient at position 0.2.

Works best with grayscale "height maps."

Here are some examples:

![slice](https://cloud.githubusercontent.com/assets/10934467/6544743/5f85846e-c55e-11e4-8dd4-79a162c5d9a8.png) ![blue](https://cloud.githubusercontent.com/assets/10934467/6544744/5f889870-c55e-11e4-9383-a493e8642a9a.png) ![terrain](https://cloud.githubusercontent.com/assets/10934467/6544741/5f7f594a-c55e-11e4-9413-a68bc482f715.png)
![slice-gradient](https://cloud.githubusercontent.com/assets/10934467/6544745/5f890ee0-c55e-11e4-8df8-4554d0a1c427.png) ![blue-gradient](https://cloud.githubusercontent.com/assets/10934467/6544742/5f8336f0-c55e-11e4-97f7-30185c52ef0b.png) ![terrain-gradient](https://cloud.githubusercontent.com/assets/10934467/6544740/5f7a7e5c-c55e-11e4-8db6-179dc4f63392.png)
