### PR TITLE
Added Normalize

### DIFF
--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -622,6 +622,45 @@ TG.Pixelate = function () {
 
 };
 
+TG.Normalize = function () {
+
+	var params = {
+		multiplier: 0,
+		offset: 0
+	}
+
+	return new TG.Program( {
+		getParams: function () {
+			return params;
+		},
+		getSource: function () {
+			return [
+				'if ( !params.init ) {',
+					'var high = -Infinity;',
+					'var low = Infinity;',
+
+					'for ( var j = 0, len = src.array.length; j < len; j++ ) {',
+						'if ( j % 4 == 3 ) continue;',
+
+						'high = ( src.array[ j ] > high ) ? src.array[ j ] : high;',
+						'low  = ( src.array[ j ] < low  ) ? src.array[ j ] : low;',
+					'}',
+
+					'params.offset = -low;',
+					'params.multiplier = 1 / ( high - low );',
+					'params.init = true;',
+				'}',
+
+				'var v = src.getPixelNearest( x, y );',
+				'color[ 0 ] = ( v[ 0 ] + params.offset ) * params.multiplier;',
+				'color[ 1 ] = ( v[ 1 ] + params.offset ) * params.multiplier;',
+				'color[ 2 ] = ( v[ 2 ] + params.offset ) * params.multiplier;'
+			].join( '\n' );
+
+		}
+	} );
+};
+
 // Buffer
 
 TG.Buffer = function ( width, height ) {


### PR DESCRIPTION
The normalize filter maps the colors of the image to values between 0 and 1, so that the lowest point is at 0 and the highest at 1.
This is especially useful for gradient maps.

For example, by default sines are generated from -1 to 1. After normalization the high points are still at 1 but the low points are now at 0 and everything in between has been modified accordingly:

![sine](https://cloud.githubusercontent.com/assets/10934467/6544816/972d6424-c561-11e4-9cf9-b8dad21254af.png) ![normalized sine](https://cloud.githubusercontent.com/assets/10934467/6544817/972e40ba-c561-11e4-9699-16b19d0a30a8.png)
