### PR TITLE
Fixed repeat for gradients

### DIFF
--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -868,37 +868,11 @@ TG.ColorInterpolator.prototype = {
 
 	getColorAt: function ( pos ) {
 		var range = ( this.high - this.low );
-
+		
 		if ( pos > this.high ) {
-
-			if ( this.repeat ) {
-				pos -= this.low;
-
-				if ( this.repeat >= 2 ) {
-					var flip = Math.abs( Math.floor( pos / range ) % 2 ); // due to rounding errors here, sometimes it flips one pixel too early...
-					pos = ( flip == 1 ) ? -pos : pos;
-				}
-
-				pos = ( range + pos % range ) % range;
-
-				pos += this.low;
-			} else pos = this.high;
-
+			pos = ( this.repeat ) ? ( ( range + ( pos - this.low ) % range ) % range ) + this.low : this.high;
 		} else if ( pos < this.low ) {
-
-			if ( this.repeat ) {
-				pos -= this.low;
-
-				if ( this.repeat >= 2 ) {
-					var flip = Math.abs( Math.floor( pos / range ) % 2 );
-					pos = ( flip == 1 ) ? -pos : pos;
-				}
-
-				pos = ( range + pos % range ) % range;
-
-				pos += this.low;
-			} else pos = this.low;
-
+			pos = ( this.repeat ) ? ( ( range + ( pos - this.low ) % range ) % range ) + this.low : this.low;
 		}
 
 		var i = 0, points = this.points;

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -867,12 +867,39 @@ TG.ColorInterpolator.prototype = {
 	},
 
 	getColorAt: function ( pos ) {
+		var range = ( this.high - this.low );
 
-		if ( pos > this.high )
-			pos = this.repeat ? pos % this.high : this.high;
+		if ( pos > this.high ) {
 
-		if ( pos < this.low )
-			pos = this.repeat ? pos % this.low : this.low;
+			if ( this.repeat ) {
+				pos -= this.low;
+
+				if ( this.repeat >= 2 ) {
+					var flip = Math.abs( Math.floor( pos / range ) % 2 ); // due to rounding errors here, sometimes it flips one pixel too early...
+					pos = ( flip == 1 ) ? -pos : pos;
+				}
+
+				pos = ( range + pos % range ) % range;
+
+				pos += this.low;
+			} else pos = this.high;
+
+		} else if ( pos < this.low ) {
+
+			if ( this.repeat ) {
+				pos -= this.low;
+
+				if ( this.repeat >= 2 ) {
+					var flip = Math.abs( Math.floor( pos / range ) % 2 );
+					pos = ( flip == 1 ) ? -pos : pos;
+				}
+
+				pos = ( range + pos % range ) % range;
+
+				pos += this.low;
+			} else pos = this.low;
+
+		}
 
 		var i = 0, points = this.points;
 


### PR DESCRIPTION
I realized that I totally botched the repeat for the interpolator when I added the gradient-map filter and fixed it here.

I also tried to add a mirrored repeat mode but, while it usually works like intended, sometimes it flips one pixel too early or late and returns a wrong color:

![error](https://cloud.githubusercontent.com/assets/10934467/6587565/0197e39a-c786-11e4-87ff-9b338d9c0f57.png)

I think this is a precision issue, since, when the color positions get changed a little, it doesn't happen:

![noterror](https://cloud.githubusercontent.com/assets/10934467/6587599/9902afe4-c786-11e4-8c91-a17a26d901da.png)

So the question is now, is there a solution to this or should I scrap it?
