### PR TITLE
Added Posterize

### DIFF
--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -698,6 +698,32 @@ TG.Normalize = function () {
 	} );
 };
 
+TG.Posterize = function () {
+
+	var params = {
+		step: 1
+	};
+
+	return new TG.Program( {
+		step: function ( value ) {
+			params.step = Math.max( value, 2 )
+			return this;
+		},
+		getParams: function () {
+			return params;
+		},
+		getSource: function () {
+			return [
+				'var v = src.getPixelNearest( x, y );',
+				'color[ 0 ] = Math.floor( Math.floor( v[ 0 ] * 255 / ( 255 / params.step ) ) * 255 / ( params.step - 1 ) ) / 255;',
+				'color[ 1 ] = Math.floor( Math.floor( v[ 1 ] * 255 / ( 255 / params.step ) ) * 255 / ( params.step - 1 ) ) / 255;',
+				'color[ 2 ] = Math.floor( Math.floor( v[ 2 ] * 255 / ( 255 / params.step ) ) * 255 / ( params.step - 1 ) ) / 255;'
+			].join( '\n' );
+		}
+	} );
+
+};
+
 // Buffer
 
 TG.Buffer = function ( width, height ) {

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -701,7 +701,7 @@ TG.Normalize = function () {
 TG.Posterize = function () {
 
 	var params = {
-		step: 1
+		step: 2
 	};
 
 	return new TG.Program( {


### PR DESCRIPTION
The posterize filter reduces the number of colors. Lower values for the "step" parameter results in fewer colors.

Examples:

![Before](https://cloud.githubusercontent.com/assets/10934467/6957881/66061b56-d903-11e4-9ade-24f690293694.png) ![arrow](https://cloud.githubusercontent.com/assets/10934467/6957971/fb02679a-d904-11e4-9f81-51203074b6e2.png) ![After](https://cloud.githubusercontent.com/assets/10934467/6957885/72321402-d903-11e4-9dc9-8117037f5028.png)
![Before](https://cloud.githubusercontent.com/assets/10934467/6957888/81cc67fa-d903-11e4-9a73-8016a4240de5.png) ![arrow](https://cloud.githubusercontent.com/assets/10934467/6957971/fb02679a-d904-11e4-9f81-51203074b6e2.png) ![After](https://cloud.githubusercontent.com/assets/10934467/6957890/8dc51084-d903-11e4-8adc-3cdd3c9756fe.png)
