### PR TITLE
Some minor things that have been piling up

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Procedural Texture Generator
 ```javascript
 var texture = new TG.Texture( 256, 256 )
     .add( new TG.XOR().tint( 1, 0.5, 0.7 ) )
-    .add( new TG.SinX().frequency( 0.004 ).tint( 0.5, 0, 0 ) )
-    .mul( new TG.SinY().frequency( 0.004 ).tint( 0.5, 0, 0 ) )
-    .add( new TG.SinX().frequency( 0.0065 ).tint( 0.1, 0.5, 0.2 ) )
-    .add( new TG.SinY().frequency( 0.0065 ).tint( 0.5, 0.5, 0.5 ) )
+    .add( new TG.SinX().frequency( 500 ).tint( 0.5, 0, 0 ) )
+    .mul( new TG.SinY().frequency( 500 ).tint( 0.5, 0, 0 ) )
+    .add( new TG.SinX().frequency( 2 / 0.0065 ).tint( 0.1, 0.5, 0.2 ) )
+    .add( new TG.SinY().frequency( 2 / 0.0065 ).tint( 0.5, 0.5, 0.5 ) )
     .add( new TG.Noise().tint( 0.1, 0.1, 0.2 ) )
     .toCanvas();
 

--- a/examples/animated.html
+++ b/examples/animated.html
@@ -34,7 +34,7 @@
 					.mul( new TG.SinX().frequency( 0.08-i/2000 ) )
 					.add( new TG.SinY().frequency( 0.05-i/1000 ) )
 					.mul( new TG.SinY().frequency( 0.08+i/2000 ) )
-					.div( new TG.Number().tint( 1, 2, 1 ) )
+					.div( new TG.Fill().tint( 1, 2, 1 ) )
 					.add( new TG.SinX().frequency( 0.003 ).tint( 0.5, 0, 0 ) )
 					.toImageData(context);
 
@@ -47,7 +47,7 @@
 					.add( new TG.SinY().frequency( 0.066 + 0.05*Math.sin(i/100) ) )
 					.mul( new TG.SinX().offset( 32 ).frequency( 0.044 + 0.09*Math.sin(i/100) ).tint( 2, 2, 2 ) )
 					.mul( new TG.SinY().offset( 16 ).frequency( 0.044 + 0.09*Math.sin(i/100) ).tint( 2, 2, 2 ) )
-					.sub( new TG.Number().tint( 0.5, 2, 4 ) )
+					.sub( new TG.Fill().tint( 0.5, 2, 4 ) )
 					.toImageData(context);
 
 				context.putImageData( texture, size, 0 );

--- a/examples/animated.html
+++ b/examples/animated.html
@@ -30,12 +30,12 @@
 			function render() {
 
 				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().frequency( 0.05+i/1000 ) )
-					.mul( new TG.SinX().frequency( 0.08-i/2000 ) )
-					.add( new TG.SinY().frequency( 0.05-i/1000 ) )
-					.mul( new TG.SinY().frequency( 0.08+i/2000 ) )
+					.add( new TG.SinX().frequency( 2/(0.05+i/1000) ) )
+					.mul( new TG.SinX().frequency( 2/(0.08-i/2000) ) )
+					.add( new TG.SinY().frequency( 2/(0.05-i/1000) ) )
+					.mul( new TG.SinY().frequency( 2/(0.08+i/2000) ) )
 					.div( new TG.Fill().tint( 1, 2, 1 ) )
-					.add( new TG.SinX().frequency( 0.003 ).tint( 0.5, 0, 0 ) )
+					.add( new TG.SinX().frequency( 2/0.003 ).tint( 0.5, 0, 0 ) )
 					.toImageData(context);
 
 				context.putImageData( texture, 0, 0 );
@@ -43,10 +43,10 @@
 				//
 
 				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().frequency( 0.066 + 0.05*Math.sin(i/100) ) )
-					.add( new TG.SinY().frequency( 0.066 + 0.05*Math.sin(i/100) ) )
-					.mul( new TG.SinX().offset( 32 ).frequency( 0.044 + 0.09*Math.sin(i/100) ).tint( 2, 2, 2 ) )
-					.mul( new TG.SinY().offset( 16 ).frequency( 0.044 + 0.09*Math.sin(i/100) ).tint( 2, 2, 2 ) )
+					.add( new TG.SinX().frequency( 2/(0.066 + 0.05*Math.sin(i/100)) ) )
+					.add( new TG.SinY().frequency( 2/(0.066 + 0.05*Math.sin(i/100)) ) )
+					.mul( new TG.SinX().offset( 32 ).frequency( 2/(0.044 + 0.09*Math.sin(i/100)) ).tint( 2, 2, 2 ) )
+					.mul( new TG.SinY().offset( 16 ).frequency( 2/(0.044 + 0.09*Math.sin(i/100)) ).tint( 2, 2, 2 ) )
 					.sub( new TG.Fill().tint( 0.5, 2, 4 ) )
 					.toImageData(context);
 
@@ -55,10 +55,10 @@
 				//
 
 				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().frequency( 0.004 + 0.002*Math.sin(i/100)) )
-					.mul( new TG.SinY().frequency( 0.004	+ 0.002*Math.sin(i/100)) )
-					.mul( new TG.SinY().offset( 32 ).frequency( 0.04 + 0.02*Math.sin(i/100) ) )
-					.div( new TG.SinX().frequency( 0.02 ).tint( 8, 5, 4 ) )
+					.add( new TG.SinX().frequency( 2/(0.004 + 0.002*Math.sin(i/100))) )
+					.mul( new TG.SinY().frequency( 2/(0.004	+ 0.002*Math.sin(i/100))) )
+					.mul( new TG.SinY().offset( 32 ).frequency( 2/(0.04 + 0.02*Math.sin(i/100)) ) )
+					.div( new TG.SinX().frequency( 2/0.02 ).tint( 8, 5, 4 ) )
 					.add( new TG.Noise().tint( 0.1, 0, 0 ) )
 					.add( new TG.Noise().tint( 0, 0.1, 0 ) )
 					.add( new TG.Noise().tint( 0, 0, 0.1 ) )

--- a/examples/index.html
+++ b/examples/index.html
@@ -50,7 +50,26 @@
 				-o-tab-size:   4;
 				tab-size:      4;*/
 			}
+			
+			.cm-keyword { color: #d687a2; }
+			.cm-atom { color: #119a6c; }
+			.cm-number { color: #8b6194; }
+			.cm-def { color: #608ba7; }
+			.cm-variable { color: #a3bac1; }
+			.cm-property { color: #6f979a; } 
+			.cm-operator { color: #d08f64; }
+			.cm-variable-2 { color: #a3bac1; opacity: 0.8; }
+			.cm-variable-3 { color: #a3bac1; opacity: 0.6; }
+			.cm-comment { opacity: 0.25; }
+			.cm-string { color: #a05e55; }
+			.cm-string-2 { color: #964b40; }
+
+			.cm-error { color: #cc1d29; }
+			.cm-invalidchar { color: #cc1d29; }
 		</style>
+		
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/addon/runmode/runmode-standalone.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/javascript/javascript.min.js"></script>
 	</head>
 	<body>
 		<p>Change size: <a href="#128">128x128</a> <a href="#256">256x256</a> <a href="#512">512x512</a> <a id="customSize" href="javascript:void();">custom...</a></p>
@@ -64,392 +83,319 @@
 			var generated = document.getElementById( "generated" );
 			var examples = [];
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.XOR().tint( 1, 0.5, 0.7 ) )
-					.add( new TG.SinX().frequency( size / 2 ).tint( 0.25, 0, 0 ) )
-					.sub( new TG.SinY().frequency( size / 2 ).tint( 0.25, 0, 0 ) )
-					.add( new TG.SinX().frequency( size / 0.8 ).tint( 0.1, 0.5, 0.2 ) )
-					.add( new TG.SinY().frequency( size / 0.8 ).tint( 0, 0.4, 0.5 ) )
-					.add( new TG.Noise().tint( 0.1, 0.1, 0.2 ) )
-					.toCanvas();
-					return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.XOR().tint( 1, 0.5, 0.7 ) )',
+				'	.add( new TG.SinX().frequency( size / 2 ).tint( 0.25, 0, 0 ) )',
+				'	.sub( new TG.SinY().frequency( size / 2 ).tint( 0.25, 0, 0 ) )',
+				'	.add( new TG.SinX().frequency( size / 0.8 ).tint( 0.1, 0.5, 0.2 ) )',
+				'	.add( new TG.SinY().frequency( size / 0.8 ).tint( 0, 0.4, 0.5 ) )',
+				'	.add( new TG.Noise().tint( 0.1, 0.1, 0.2 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().offset( size / 16 ).frequency( size / 3 ).tint( 0.1, 0.25, 0.5 ) )
-					.add( new TG.SinY().offset( size / 16 ).frequency( size / 3 ).tint( 0.1, 0.25, 0.5 ) )
-					.add( new TG.Fill().tint( 0.75, 0.5, 0.5 ) )
-					.add( new TG.SinX().frequency( size / 3 ).tint( 0.2 ) )
-					.add( new TG.SinY().frequency( size / 3 ).tint( 0.2 ) )
-					.add( new TG.Noise().tint( 0.1, 0, 0 ) )
-					.add( new TG.Noise().tint( 0, 0.1, 0 ) )
-					.add( new TG.Noise().tint( 0, 0, 0.1 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.SinX().offset( size / 16 ).frequency( size / 3 ).tint( 0.1, 0.25, 0.5 ) )',
+				'	.add( new TG.SinY().offset( size / 16 ).frequency( size / 3 ).tint( 0.1, 0.25, 0.5 ) )',
+				'	.add( new TG.Fill().tint( 0.75, 0.5, 0.5 ) )',
+				'	.add( new TG.SinX().frequency( size / 3 ).tint( 0.2 ) )',
+				'	.add( new TG.SinY().frequency( size / 3 ).tint( 0.2 ) )',
+				'	.add( new TG.Noise().tint( 0.1, 0, 0 ) )',
+				'	.add( new TG.Noise().tint( 0, 0.1, 0 ) )',
+				'	.add( new TG.Noise().tint( 0, 0, 0.1 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().frequency( size / 12.8 ) )
-					.mul( new TG.SinX().frequency( size / 6.4 ) )
-					.mul( new TG.SinX().frequency( size / 3.2 ) )
-					.mul( new TG.SinY().frequency( size / 12.8 ) )
-					.mul( new TG.SinY().frequency( size / 6.4 ) )
-					.mul( new TG.SinY().frequency( size / 3.2 ) )
-					.add( new TG.SinX().frequency( size * 2 ).tint( -0.25, 0.1, 0.6 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.SinX().frequency( size / 12.8 ) )',
+				'	.mul( new TG.SinX().frequency( size / 6.4 ) )',
+				'	.mul( new TG.SinX().frequency( size / 3.2 ) )',
+				'	.mul( new TG.SinY().frequency( size / 12.8 ) )',
+				'	.mul( new TG.SinY().frequency( size / 6.4 ) )',
+				'	.mul( new TG.SinY().frequency( size / 3.2 ) )',
+				'	.add( new TG.SinX().frequency( size * 2 ).tint( -0.25, 0.1, 0.6 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.XOR() )
-					.mul( new TG.OR().tint( 0.5, 0.8, 0.5 ) )
-					.mul( new TG.SinX().frequency( 64 ) )
-					.div( new TG.SinY().frequency( 64 ) )
-					.add( new TG.SinX().frequency( 512 ).tint( 0.5, 0, 0 ) )
-					.add( new TG.Noise().tint( 0.1, 0.1, 0.2 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.XOR() )',
+				'	.mul( new TG.OR().tint( 0.5, 0.8, 0.5 ) )',
+				'	.mul( new TG.SinX().frequency( 64 ) )',
+				'	.div( new TG.SinY().frequency( 64 ) )',
+				'	.add( new TG.SinX().frequency( 512 ).tint( 0.5, 0, 0 ) )',
+				'	.add( new TG.Noise().tint( 0.1, 0.1, 0.2 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().frequency( 2 / 0.01 ) )
-					.mul( new TG.SinY().frequency( 2 / 0.0075 ) )
-					.add( new TG.SinX().frequency( 2 / 0.0225 ) )
-					.mul( new TG.SinY().frequency( 2 / 0.015 ) )
-					.add( new TG.Noise().tint( 0.1, 0.1, 0.3 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.SinX().frequency( 2 / 0.01 ) )',
+				'	.mul( new TG.SinY().frequency( 2 / 0.0075 ) )',
+				'	.add( new TG.SinX().frequency( 2 / 0.0225 ) )',
+				'	.mul( new TG.SinY().frequency( 2 / 0.015 ) )',
+				'	.add( new TG.Noise().tint( 0.1, 0.1, 0.3 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().frequency( 40 ) )
-					.mul( new TG.SinX().frequency( 25 ) )
-					.add( new TG.SinY().frequency( 40 ) )
-					.mul( new TG.SinY().frequency( 25 ) )
-					.div( new TG.Fill().tint( 1, 2, 1 ) )
-					.add( new TG.SinX().frequency( 1 / 0.003 ).tint( 0.5, 0, 0 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.SinX().frequency( 40 ) )',
+				'	.mul( new TG.SinX().frequency( 25 ) )',
+				'	.add( new TG.SinY().frequency( 40 ) )',
+				'	.mul( new TG.SinY().frequency( 25 ) )',
+				'	.div( new TG.Fill().tint( 1, 2, 1 ) )',
+				'	.add( new TG.SinX().frequency( 1 / 0.003 ).tint( 0.5, 0, 0 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().frequency( size / 8.6 ) )
-					.add( new TG.SinY().frequency( size / 8.6 ) )
-					.mul( new TG.SinX().offset( -32 ).frequency( size / 6.4 ).tint( 2 ) )
-					.mul( new TG.SinY().offset( -16 ).frequency( size / 6.4 ).tint( 2 ) )
-					.sub( new TG.Fill().tint( 0.5, 2, 4 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.SinX().frequency( size / 8.6 ) )',
+				'	.add( new TG.SinY().frequency( size / 8.6 ) )',
+				'	.mul( new TG.SinX().offset( -32 ).frequency( size / 6.4 ).tint( 2 ) )',
+				'	.mul( new TG.SinY().offset( -16 ).frequency( size / 6.4 ).tint( 2 ) )',
+				'	.sub( new TG.Fill().tint( 0.5, 2, 4 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().frequency( size * 2 ) )
-					.mul( new TG.SinY().frequency( size * 2 ) )
-					.mul( new TG.SinY().offset( -size / 8 ).frequency( size / 2 ) )
-					.div( new TG.SinX().frequency( size / 2 ).tint( 8, 5, 4 ) )
-					.add( new TG.Noise().tint( 0.1, 0, 0 ) )
-					.add( new TG.Noise().tint( 0, 0.1, 0 ) )
-					.add( new TG.Noise().tint( 0, 0, 0.1 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.SinX().frequency( size * 2 ) )',
+				'	.mul( new TG.SinY().frequency( size * 2 ) )',
+				'	.mul( new TG.SinY().offset( -size / 8 ).frequency( size / 2 ) )',
+				'	.div( new TG.SinX().frequency( size / 2 ).tint( 8, 5, 4 ) )',
+				'	.add( new TG.Noise().tint( 0.1, 0, 0 ) )',
+				'	.add( new TG.Noise().tint( 0, 0.1, 0 ) )',
+				'	.add( new TG.Noise().tint( 0, 0, 0.1 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.CheckerBoard() )
-					.add( new TG.CheckerBoard().size( 2 ).tint( 0.5, 0, 0 ) )
-					.add( new TG.CheckerBoard().size( 8 ).tint( 1, 0.5, 0.5 ) )
-					.sub( new TG.CheckerBoard().offset( -16, -16 ).tint( 0.5, 0.5, 0 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.CheckerBoard() )',
+				'	.add( new TG.CheckerBoard().size( 2 ).tint( 0.5, 0, 0 ) )',
+				'	.add( new TG.CheckerBoard().size( 8 ).tint( 1, 0.5, 0.5 ) )',
+				'	.sub( new TG.CheckerBoard().offset( -16, -16 ).tint( 0.5, 0.5, 0 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.Rect().position( size / 4.8, size / 12 ).size( size / 1.7, size / 2 ).tint( 1, 0.25, 0.25 ) )
-					.add( new TG.Rect().position( size / 12, size / 4 ).size( size / 1.21, size / 2 ).tint( 0.25, 1, 0.25 ) )
-					.add( new TG.Rect().position( size / 4.8, size / 2.5 ).size( size / 1.7, size / 2 ).tint( 0.25, 0.25, 1 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.Rect().position( size / 4.8, size / 12 ).size( size / 1.7, size / 2 ).tint( 1, 0.25, 0.25 ) )',
+				'	.add( new TG.Rect().position( size / 12, size / 4 ).size( size / 1.21, size / 2 ).tint( 0.25, 1, 0.25 ) )',
+				'	.add( new TG.Rect().position( size / 4.8, size / 2.5 ).size( size / 1.7, size / 2 ).tint( 0.25, 0.25, 1 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.CheckerBoard().size( 32 ).tint( 0.5, 0, 0 ) )
-					.set( new TG.SineDistort() )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.CheckerBoard().size( 32 ).tint( 0.5, 0, 0 ) )',
+				'	.set( new TG.SineDistort() )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.CheckerBoard().size( 32 ).tint( 0.5, 0, 0 ) )
-					.set( new TG.Twirl().radius( size / 2 ).position( size / 2, size / 2 ).strength ( 75 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.CheckerBoard().size( 32 ).tint( 0.5, 0, 0 ) )',
+				'	.set( new TG.Twirl().radius( size / 2 ).position( size / 2, size / 2 ).strength ( 75 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.Circle().position( size / 2, size / 2 ).radius( size / 4 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.Circle().position( size / 2, size / 2 ).radius( size / 4 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.Circle().position( size / 2, size / 2 ).radius( size / 4 ).delta( size / 4 ).tint( 1, 0.25, 0.25 ) )
-					.set( new TG.Pixelate().size( size / 32 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.Circle().position( size / 2, size / 2 ).radius( size / 4 ).delta( size / 4 ).tint( 1, 0.25, 0.25 ) )',
+				'	.set( new TG.Pixelate().size( size / 32 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.CheckerBoard().tint( 1, 1, 0 ) )
-					.set( new TG.Transform().offset( 10, 20 ).angle( 23 ).scale( 2, 0.5 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.CheckerBoard().tint( 1, 1, 0 ) )',
+				'	.set( new TG.Transform().offset( 10, 20 ).angle( 23 ).scale( 2, 0.5 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.CheckerBoard() )
-					.and( new TG.Circle().position( size / 2, size / 2 ).radius( size / 3 ) )
-					.xor( new TG.Circle().position( size / 2, size / 2 ).radius( size / 4 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.CheckerBoard() )',
+				'	.and( new TG.Circle().position( size / 2, size / 2 ).radius( size / 3 ) )',
+				'	.xor( new TG.Circle().position( size / 2, size / 2 ).radius( size / 4 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.CheckerBoard().size( size / 16 ) )
-					.set( new TG.Twirl().radius( size / 2 ).strength( 75 ).position( size / 2, size / 2 ) )
-					.min( new TG.Circle().position( size / 2, size / 2 ).radius( size / 2 ).delta( size / 2 ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.CheckerBoard().size( size / 16 ) )',
+				'	.set( new TG.Twirl().radius( size / 2 ).strength( 75 ).position( size / 2, size / 2 ) )',
+				'	.min( new TG.Circle().position( size / 2, size / 2 ).radius( size / 2 ).delta( size / 2 ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.LinearGradient().interpolation( 0 )
-						.point( 0, [ 1, 1, 0 ] )
-						.point( 0.25, [ 0.2, 0, 0.5 ] )
-						.point( 0.5, [ 0.5, 0.2, 0.5 ] )
-						.point( 1, [ 1, 0, 1 ] ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.LinearGradient().interpolation( 0 )',
+				'		.point( 0, [ 1, 1, 0 ] )',
+				'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
+				'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
+				'		.point( 1, [ 1, 0, 1 ] ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.LinearGradient().interpolation( 1 )
-						.point( 0, [ 1, 1, 0 ] )
-						.point( 0.25, [ 0.2, 0, 0.5 ] )
-						.point( 0.5, [ 0.5, 0.2, 0.5 ] )
-						.point( 1, [ 1, 0, 1 ] ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.LinearGradient().interpolation( 1 )',
+				'		.point( 0, [ 1, 1, 0 ] )',
+				'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
+				'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
+				'		.point( 1, [ 1, 0, 1 ] ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.LinearGradient().interpolation( 2 )
-						.point( 0, [ 1, 1, 0 ] )
-						.point( 0.25, [ 0.2, 0, 0.5 ] )
-						.point( 0.5, [ 0.5, 0.2, 0.5 ] )
-						.point( 1, [ 1, 0, 1 ] ) )
-					.toCanvas();
-
-
-				return texture;
-			});
-
-
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.LinearGradient().interpolation( 2 )',
+				'		.point( 0, [ 1, 1, 0 ] )',
+				'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
+				'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
+				'		.point( 1, [ 1, 0, 1 ] ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.RadialGradient().center( size / 2, size / 2 ).radius( size / 8 ).repeat( true ).interpolation( 0 )
-						.point( 0, [ 1, 1, 0 ] )
-						.point( 0.25, [ 0.2, 0, 0.5 ] )
-						.point( 0.5, [ 0.5, 0.2, 0.5 ] )
-						.point( 1, [ 1, 0, 1 ] ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.RadialGradient().center( size / 2, size / 2 ).radius( size / 8 ).repeat( true ).interpolation( 0 )',
+				'		.point( 0, [ 1, 1, 0 ] )',
+				'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
+				'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
+				'		.point( 1, [ 1, 0, 1 ] ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.RadialGradient().center( 0, 0 ).radius( size * 2 ).interpolation( 1 )
-						.point( 0, [ 1, 1, 0 ] )
-						.point( 0.25, [ 0.2, 0, 0.5 ] )
-						.point( 0.5, [ 0.5, 0.2, 0.5 ] )
-						.point( 1, [ 1, 0, 1 ] ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.RadialGradient().center( 0, 0 ).radius( size * 2 ).interpolation( 1 )',
+				'		.point( 0, [ 1, 1, 0 ] )',
+				'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
+				'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
+				'		.point( 1, [ 1, 0, 1 ] ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//
 
-			examples.push( function ( size ) {
-				var texture = new TG.Texture( size, size )
-					.add( new TG.RadialGradient().center( size / 2, 0 ).radius( size ).interpolation( 2 )
-						.point( 0, [ 1, 1, 0 ] )
-						.point( 0.25, [ 0.2, 0, 0.5 ] )
-						.point( 0.5, [ 0.5, 0.2, 0.5 ] )
-						.point( 1, [ 1, 0, 1 ] ) )
-					.toCanvas();
-
-
-				return texture;
-			});
+			examples.push([
+				'var texture = new TG.Texture( size, size )',
+				'	.add( new TG.RadialGradient().center( size / 2, 0 ).radius( size ).interpolation( 2 )',
+				'		.point( 0, [ 1, 1, 0 ] )',
+				'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
+				'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
+				'		.point( 1, [ 1, 0, 1 ] ) )',
+				'	.toCanvas();'
+			].join( "\n" ));
 
 			//---- Put-Texture ----
 
-			examples.push( function ( size ) {
-				vignette = new TG.Texture( size, size )		// predefine a vignette-effect so it can be used later
-					.set( new TG.Circle().radius( size ).position( size / 2, size / 2 ).delta( size * 0.7 ) );
-
-				var numSamples = 6;		// more samples = heavier effect
-
-				var base = new TG.Texture( size, size )		// generating an image to be blurred
-					.set( new TG.FractalNoise().amplitude( 0.46 ).persistence( 0.78 ).interpolation( 0 ) )
-					.set( new TG.Normalize() );
-
-				var blur = new TG.Texture( size, size );		// the texture the samples are put onto
-
-				for ( i = 0; i <= numSamples; i++ ) {
-					var sample = new TG.Texture( size, size )
-					.set( new TG.PutTexture( base ) ) 		// copy the base texture, so that it doesn't get modified
-					.set( new TG.Transform().scale( 1 + 0.01 * i ).angle( 0.5 * i ) );		// modify the texture a bit more with each sample
-
-					blur.add( new TG.PutTexture( sample ) );		// adding the transformed sample to the result
-				}
-
-				blur.set( new TG.Normalize() )		// since the samples are not weighted, put everything in the visible range
-					.mul( new TG.PutTexture( vignette ) );		// adding the predefined vignette-effect
-
-				base.toCanvas();		// since we copied the base texture instead of modifying it directly, we can still use it how it was before
-
-				var texture = blur.toCanvas();
-
-				return texture;
-			});
+			examples.push([
+				'vignette = new TG.Texture( size, size )		// predefine a vignette-effect so it can be used later',
+				'	.set( new TG.Circle().radius( size ).position( size / 2, size / 2 ).delta( size * 0.7 ) );',
+				'	',
+				'var numSamples = 6;		// more samples = heavier effect',
+				'',
+				'var base = new TG.Texture( size, size )		// generating an image to be blurred',
+				'	.set( new TG.FractalNoise().amplitude( 0.46 ).persistence( 0.78 ).interpolation( 0 ) )',
+				'	.set( new TG.Normalize() );',
+				'',
+				'var blur = new TG.Texture( size, size );		// the texture the samples are put onto',
+				'',
+				'for ( i = 0; i <= numSamples; i++ ) {',
+				'	var sample = new TG.Texture( size, size )',
+				'	.set( new TG.PutTexture( base ) ) 		// copy the base texture, so that it doesn\'t get modified',
+				'	.set( new TG.Transform().scale( 1 + 0.01 * i ).angle( 0.5 * i ) );		// modify the texture a bit more with each sample',
+				'',
+				'	blur.add( new TG.PutTexture( sample ) );		// adding the transformed sample to the result',
+				'}',
+				'',
+				'blur.set( new TG.Normalize() )		// since the samples are not weighted, put everything in the visible range',
+				'	.mul( new TG.PutTexture( vignette ) );		// adding the predefined vignette-effect',
+				'',
+				'base.toCanvas();		// since we copied the base texture instead of modifying it directly, we can still use it how it was before',
+				'',
+				'var texture = blur.toCanvas();'
+			].join( "\n" ));
 
 			//----
 
-			examples.push( function ( size ) {
-				var subDim = Math.floor( size / 4 );		// generate a smaller image so it can be mirrored later
-
-				var pixel = new TG.Texture( subDim, subDim )
-					.set( new TG.FractalNoise().baseFrequency( subDim / 15 ).octaves( 1 ).amplitude( 1 ) )		// generating a noise pattern with 15 pixels per length
-					.set( new TG.GradientMap().interpolation( 0 )		// divide the generated values into defined colors
-						.point( 0, [ 250, 230, 210 ] )		//[ 251, 255, 228 ] (alternative colors)
-						.point( 0.2, [ 255, 92, 103 ] )		//[ 130, 198, 184 ]
-						.point( 0.4, [ 200, 15, 17 ] )		//[ 42, 166, 137 ]
-						.point( 0.6, [ 140, 49, 59 ] )		//[ 58, 131, 114 ]
-						.point( 0.8, [ 35, 10, 12 ] )		//[ 4, 46, 27 ]
-						.point( 1, 0 ) )
-					.div( new TG.Fill().tint( 255 ) );		// converting the 0-255 defined colors to the 0-1 space
-
-				var mirrored = new TG.Texture( size, size )
-					.add( new TG.PutTexture( pixel ).repeat( 2 ) )		// repeat the texture to get a cool mirrored pattern effect
-					.mul( new TG.PutTexture( vignette ).tint( 1.2 ) );		// adding the vignette from the example above
-
-				var texture = mirrored.toCanvas();
-				
-				return texture;
-			});
+			examples.push([
+				'var subDim = Math.floor( size / 4 );		// generate a smaller image so it can be mirrored later',
+				'',
+				'var pixel = new TG.Texture( subDim, subDim )',
+				'	.set( new TG.FractalNoise().baseFrequency( subDim / 15 ).octaves( 1 ).amplitude( 1 ) )		// generating a noise pattern with 15 pixels per length',
+				'	.set( new TG.GradientMap().interpolation( 0 )		// divide the generated values into defined colors',
+				'		.point( 0, [ 250, 230, 210 ] )		//[ 251, 255, 228 ] (alternative colors)',
+				'		.point( 0.2, [ 255, 92, 103 ] )		//[ 130, 198, 184 ]',
+				'		.point( 0.4, [ 200, 15, 17 ] )		//[ 42, 166, 137 ]',
+				'		.point( 0.6, [ 140, 49, 59 ] )		//[ 58, 131, 114 ]',
+				'		.point( 0.8, [ 35, 10, 12 ] )		//[ 4, 46, 27 ]',
+				'		.point( 1, 0 ) )',
+				'	.div( new TG.Fill().tint( 255 ) );		// converting the 0-255 defined colors to the 0-1 space',
+				'',
+				'var mirrored = new TG.Texture( size, size )',
+				'	.add( new TG.PutTexture( pixel ).repeat( 2 ) )		// repeat the texture to get a cool mirrored pattern effect',
+				'	.mul( new TG.PutTexture( vignette ).tint( 1.2 ) );		// adding the vignette from the example above',
+				'',
+				'var texture = mirrored.toCanvas();'
+			].join( "\n" ));
 			
 			//----------------
 			
@@ -459,12 +405,10 @@
 				var div = document.createElement( "div" );
 				var source = document.createElement( "pre" );
 				
-				source.innerHTML = examples[ a ].toString()
-					.replace( /([\n\t]+return[\s\S]+)|(^\t{4})/gm, "" )
-					.replace( /^[\s\S]+?\n/, "" )
-					.replace( /\t/g, "    " );
+				CodeMirror.runMode(examples[ a ], "javascript", source);
 				
-				div.appendChild( examples[ a ]( s ) );
+				var func = new Function("size", examples[ a ] + "\nreturn texture;") 
+				div.appendChild( func( s ) );
 				div.appendChild( source );
 				generated.appendChild( div );
 				generated.appendChild( document.createElement( "br" ) );

--- a/examples/index.html
+++ b/examples/index.html
@@ -82,7 +82,7 @@
 				var texture = new TG.Texture( size, size )
 					.add( new TG.SinX().offset( - 16 ).frequency( 0.03 ).tint( 0.1, 0.25, 0.5 ) )
 					.add( new TG.SinY().offset( - 16 ).frequency( 0.03 ).tint( 0.1, 0.25, 0.5 ) )
-					.add( new TG.Number().tint( 0.75, 0.5, 0.5 ) )
+					.add( new TG.Fill().tint( 0.75, 0.5, 0.5 ) )
 					.add( new TG.SinX().frequency( 0.03 ).tint( 0.2, 0.2, 0.2 ) )
 					.add( new TG.SinY().frequency( 0.03 ).tint( 0.2, 0.2, 0.2 ) )
 					.add( new TG.Noise().tint( 0.1, 0, 0 ) )
@@ -150,7 +150,7 @@
 					.mul( new TG.SinX().frequency( 0.08 ) )
 					.add( new TG.SinY().frequency( 0.05 ) )
 					.mul( new TG.SinY().frequency( 0.08 ) )
-					.div( new TG.Number().tint( 1, 2, 1 ) )
+					.div( new TG.Fill().tint( 1, 2, 1 ) )
 					.add( new TG.SinX().frequency( 0.003 ).tint( 0.5, 0, 0 ) )
 					.toCanvas();
 
@@ -166,7 +166,7 @@
 					.add( new TG.SinY().frequency( 0.066 ) )
 					.mul( new TG.SinX().offset( 32 ).frequency( 0.044 ).tint( 2, 2, 2 ) )
 					.mul( new TG.SinY().offset( 16 ).frequency( 0.044 ).tint( 2, 2, 2 ) )
-					.sub( new TG.Number().tint( 0.5, 2, 4 ) )
+					.sub( new TG.Fill().tint( 0.5, 2, 4 ) )
 					.toCanvas();
 
 
@@ -440,7 +440,7 @@
 						.point( 0.6, [ 140, 49, 59 ] )		//[ 58, 131, 114 ]
 						.point( 0.8, [ 35, 10, 12 ] )		//[ 4, 46, 27 ]
 						.point( 1, [ 0, 0, 0 ] ) )
-					.div( new TG.Number().tint( 255, 255, 255 ) );		// converting the 0-255 defined colors to the 0-1 space
+					.div( new TG.Fill().tint( 255, 255, 255 ) );		// converting the 0-255 defined colors to the 0-1 space
 
 				var mirrored = new TG.Texture( size, size )
 					.add( new TG.PutTexture( pixel ).repeat( 2 ) )		// repeat the texture to get a cool mirrored pattern effect

--- a/examples/index.html
+++ b/examples/index.html
@@ -67,10 +67,10 @@
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
 					.add( new TG.XOR().tint( 1, 0.5, 0.7 ) )
-					.add( new TG.SinX().frequency( 0.004 ).tint( 0.25, 0, 0 ) )
-					.sub( new TG.SinY().frequency( 0.004 ).tint( 0.25, 0, 0 ) )
-					.add( new TG.SinX().frequency( 0.0065 ).tint( 0.1, 0.5, 0.2 ) )
-					.add( new TG.SinY().frequency( 0.0065 ).tint( 0, 0.4, 0.5 ) )
+					.add( new TG.SinX().frequency( size / 2 ).tint( 0.25, 0, 0 ) )
+					.sub( new TG.SinY().frequency( size / 2 ).tint( 0.25, 0, 0 ) )
+					.add( new TG.SinX().frequency( size / 0.8 ).tint( 0.1, 0.5, 0.2 ) )
+					.add( new TG.SinY().frequency( size / 0.8 ).tint( 0, 0.4, 0.5 ) )
 					.add( new TG.Noise().tint( 0.1, 0.1, 0.2 ) )
 					.toCanvas();
 					return texture;
@@ -80,11 +80,11 @@
 
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().offset( - 16 ).frequency( 0.03 ).tint( 0.1, 0.25, 0.5 ) )
-					.add( new TG.SinY().offset( - 16 ).frequency( 0.03 ).tint( 0.1, 0.25, 0.5 ) )
+					.add( new TG.SinX().offset( size / 16 ).frequency( size / 3 ).tint( 0.1, 0.25, 0.5 ) )
+					.add( new TG.SinY().offset( size / 16 ).frequency( size / 3 ).tint( 0.1, 0.25, 0.5 ) )
 					.add( new TG.Fill().tint( 0.75, 0.5, 0.5 ) )
-					.add( new TG.SinX().frequency( 0.03 ).tint( 0.2, 0.2, 0.2 ) )
-					.add( new TG.SinY().frequency( 0.03 ).tint( 0.2, 0.2, 0.2 ) )
+					.add( new TG.SinX().frequency( size / 3 ).tint( 0.2 ) )
+					.add( new TG.SinY().frequency( size / 3 ).tint( 0.2 ) )
 					.add( new TG.Noise().tint( 0.1, 0, 0 ) )
 					.add( new TG.Noise().tint( 0, 0.1, 0 ) )
 					.add( new TG.Noise().tint( 0, 0, 0.1 ) )
@@ -98,13 +98,13 @@
 
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().frequency( 0.1 ) )
-					.mul( new TG.SinX().frequency( 0.05 ) )
-					.mul( new TG.SinX().frequency( 0.025 ) )
-					.mul( new TG.SinY().frequency( 0.1 ) )
-					.mul( new TG.SinY().frequency( 0.05 ) )
-					.mul( new TG.SinY().frequency( 0.025 ) )
-					.add( new TG.SinX().frequency( 0.004 ).tint( -0.25, 0.1, 0.6 ) )
+					.add( new TG.SinX().frequency( size / 12.8 ) )
+					.mul( new TG.SinX().frequency( size / 6.4 ) )
+					.mul( new TG.SinX().frequency( size / 3.2 ) )
+					.mul( new TG.SinY().frequency( size / 12.8 ) )
+					.mul( new TG.SinY().frequency( size / 6.4 ) )
+					.mul( new TG.SinY().frequency( size / 3.2 ) )
+					.add( new TG.SinX().frequency( size * 2 ).tint( -0.25, 0.1, 0.6 ) )
 					.toCanvas();
 
 
@@ -117,9 +117,9 @@
 				var texture = new TG.Texture( size, size )
 					.add( new TG.XOR() )
 					.mul( new TG.OR().tint( 0.5, 0.8, 0.5 ) )
-					.mul( new TG.SinX().frequency( 0.0312 ) )
-					.div( new TG.SinY().frequency( 0.0312 ) )
-					.add( new TG.SinX().frequency( 0.004 ).tint( 0.5, 0, 0 ) )
+					.mul( new TG.SinX().frequency( 64 ) )
+					.div( new TG.SinY().frequency( 64 ) )
+					.add( new TG.SinX().frequency( 512 ).tint( 0.5, 0, 0 ) )
 					.add( new TG.Noise().tint( 0.1, 0.1, 0.2 ) )
 					.toCanvas();
 
@@ -131,10 +131,10 @@
 
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().frequency( 0.01 ) )
-					.mul( new TG.SinY().frequency( 0.0075 ) )
-					.add( new TG.SinX().frequency( 0.0225 ) )
-					.mul( new TG.SinY().frequency( 0.015 ) )
+					.add( new TG.SinX().frequency( 2 / 0.01 ) )
+					.mul( new TG.SinY().frequency( 2 / 0.0075 ) )
+					.add( new TG.SinX().frequency( 2 / 0.0225 ) )
+					.mul( new TG.SinY().frequency( 2 / 0.015 ) )
 					.add( new TG.Noise().tint( 0.1, 0.1, 0.3 ) )
 					.toCanvas();
 
@@ -146,12 +146,12 @@
 
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().frequency( 0.05 ) )
-					.mul( new TG.SinX().frequency( 0.08 ) )
-					.add( new TG.SinY().frequency( 0.05 ) )
-					.mul( new TG.SinY().frequency( 0.08 ) )
+					.add( new TG.SinX().frequency( 40 ) )
+					.mul( new TG.SinX().frequency( 25 ) )
+					.add( new TG.SinY().frequency( 40 ) )
+					.mul( new TG.SinY().frequency( 25 ) )
 					.div( new TG.Fill().tint( 1, 2, 1 ) )
-					.add( new TG.SinX().frequency( 0.003 ).tint( 0.5, 0, 0 ) )
+					.add( new TG.SinX().frequency( 1 / 0.003 ).tint( 0.5, 0, 0 ) )
 					.toCanvas();
 
 
@@ -162,10 +162,10 @@
 
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().frequency( 0.066 ) )
-					.add( new TG.SinY().frequency( 0.066 ) )
-					.mul( new TG.SinX().offset( 32 ).frequency( 0.044 ).tint( 2, 2, 2 ) )
-					.mul( new TG.SinY().offset( 16 ).frequency( 0.044 ).tint( 2, 2, 2 ) )
+					.add( new TG.SinX().frequency( size / 8.6 ) )
+					.add( new TG.SinY().frequency( size / 8.6 ) )
+					.mul( new TG.SinX().offset( -32 ).frequency( size / 6.4 ).tint( 2 ) )
+					.mul( new TG.SinY().offset( -16 ).frequency( size / 6.4 ).tint( 2 ) )
 					.sub( new TG.Fill().tint( 0.5, 2, 4 ) )
 					.toCanvas();
 
@@ -177,10 +177,10 @@
 
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
-					.add( new TG.SinX().frequency( 0.004 ) )
-					.mul( new TG.SinY().frequency( 0.004 ) )
-					.mul( new TG.SinY().offset( 32 ).frequency( 0.02 ) )
-					.div( new TG.SinX().frequency( 0.02 ).tint( 8, 5, 4 ) )
+					.add( new TG.SinX().frequency( size * 2 ) )
+					.mul( new TG.SinY().frequency( size * 2 ) )
+					.mul( new TG.SinY().offset( -size / 8 ).frequency( size / 2 ) )
+					.div( new TG.SinX().frequency( size / 2 ).tint( 8, 5, 4 ) )
 					.add( new TG.Noise().tint( 0.1, 0, 0 ) )
 					.add( new TG.Noise().tint( 0, 0.1, 0 ) )
 					.add( new TG.Noise().tint( 0, 0, 0.1 ) )
@@ -195,9 +195,9 @@
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
 					.add( new TG.CheckerBoard() )
-					.add( new TG.CheckerBoard().size( 2, 2 ).tint( 0.5, 0, 0 ) )
-					.add( new TG.CheckerBoard().size( 8, 8 ).tint( 1, 0.5, 0.5 ) )
-					.sub( new TG.CheckerBoard().offset( 16, 16 ).tint( 0.5, 0.5, 0 ) )
+					.add( new TG.CheckerBoard().size( 2 ).tint( 0.5, 0, 0 ) )
+					.add( new TG.CheckerBoard().size( 8 ).tint( 1, 0.5, 0.5 ) )
+					.sub( new TG.CheckerBoard().offset( -16, -16 ).tint( 0.5, 0.5, 0 ) )
 					.toCanvas();
 
 
@@ -221,7 +221,7 @@
 
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
-					.add( new TG.CheckerBoard().size( 32, 32 ).tint( 0.5, 0, 0 ) )
+					.add( new TG.CheckerBoard().size( 32 ).tint( 0.5, 0, 0 ) )
 					.set( new TG.SineDistort() )
 					.toCanvas();
 
@@ -233,7 +233,7 @@
 
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
-					.add( new TG.CheckerBoard().size( 32, 32 ).tint( 0.5, 0, 0 ) )
+					.add( new TG.CheckerBoard().size( 32 ).tint( 0.5, 0, 0 ) )
 					.set( new TG.Twirl().radius( size / 2 ).position( size / 2, size / 2 ).strength ( 75 ) )
 					.toCanvas();
 
@@ -257,7 +257,7 @@
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
 					.add( new TG.Circle().position( size / 2, size / 2 ).radius( size / 4 ).delta( size / 4 ).tint( 1, 0.25, 0.25 ) )
-					.set( new TG.Pixelate().size( size / 32, size / 32 ) )
+					.set( new TG.Pixelate().size( size / 32 ) )
 					.toCanvas();
 
 
@@ -293,7 +293,7 @@
 
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
-					.add( new TG.CheckerBoard().size( size / 16, size / 16 ) )
+					.add( new TG.CheckerBoard().size( size / 16 ) )
 					.set( new TG.Twirl().radius( size / 2 ).strength( 75 ).position( size / 2, size / 2 ) )
 					.min( new TG.Circle().position( size / 2, size / 2 ).radius( size / 2 ).delta( size / 2 ) )
 					.toCanvas();
@@ -307,10 +307,10 @@
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
 					.add( new TG.LinearGradient().interpolation( 0 )
-						.point( 0, [ 1, 1, 0, 0 ] )
-						.point( 0.25, [ 0.2, 0, 0.5, 1 ] )
-						.point( 0.5, [ 0.5, 0.2, 0.5, 1 ] )
-						.point( 1, [ 1, 0, 1, 1 ] ) )
+						.point( 0, [ 1, 1, 0 ] )
+						.point( 0.25, [ 0.2, 0, 0.5 ] )
+						.point( 0.5, [ 0.5, 0.2, 0.5 ] )
+						.point( 1, [ 1, 0, 1 ] ) )
 					.toCanvas();
 
 
@@ -322,10 +322,10 @@
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
 					.add( new TG.LinearGradient().interpolation( 1 )
-						.point( 0, [ 1, 1, 0, 0 ] )
-						.point( 0.25, [ 0.2, 0, 0.5, 1 ] )
-						.point( 0.5, [ 0.5, 0.2, 0.5, 1 ] )
-						.point( 1, [ 1, 0, 1, 1 ] ) )
+						.point( 0, [ 1, 1, 0 ] )
+						.point( 0.25, [ 0.2, 0, 0.5 ] )
+						.point( 0.5, [ 0.5, 0.2, 0.5 ] )
+						.point( 1, [ 1, 0, 1 ] ) )
 					.toCanvas();
 
 
@@ -337,10 +337,10 @@
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
 					.add( new TG.LinearGradient().interpolation( 2 )
-						.point( 0, [ 1, 1, 0, 0 ] )
-						.point( 0.25, [ 0.2, 0, 0.5, 1 ] )
-						.point( 0.5, [ 0.5, 0.2, 0.5, 1 ] )
-						.point( 1, [ 1, 0, 1, 1 ] ) )
+						.point( 0, [ 1, 1, 0 ] )
+						.point( 0.25, [ 0.2, 0, 0.5 ] )
+						.point( 0.5, [ 0.5, 0.2, 0.5 ] )
+						.point( 1, [ 1, 0, 1 ] ) )
 					.toCanvas();
 
 
@@ -354,10 +354,10 @@
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
 					.add( new TG.RadialGradient().center( size / 2, size / 2 ).radius( size / 8 ).repeat( true ).interpolation( 0 )
-						.point( 0, [ 1, 1, 0, 0 ] )
-						.point( 0.25, [ 0.2, 0, 0.5, 1 ] )
-						.point( 0.5, [ 0.5, 0.2, 0.5, 1] )
-						.point( 1, [ 1, 0, 1, 1 ] ) )
+						.point( 0, [ 1, 1, 0 ] )
+						.point( 0.25, [ 0.2, 0, 0.5 ] )
+						.point( 0.5, [ 0.5, 0.2, 0.5 ] )
+						.point( 1, [ 1, 0, 1 ] ) )
 					.toCanvas();
 
 
@@ -369,10 +369,10 @@
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
 					.add( new TG.RadialGradient().center( 0, 0 ).radius( size * 2 ).interpolation( 1 )
-						.point( 0, [ 1, 1, 0, 0 ] )
-						.point( 0.25, [ 0.2, 0, 0.5, 1 ] )
-						.point( 0.5, [ 0.5, 0.2, 0.5, 1 ] )
-						.point( 1, [ 1, 0, 1, 1 ] ) )
+						.point( 0, [ 1, 1, 0 ] )
+						.point( 0.25, [ 0.2, 0, 0.5 ] )
+						.point( 0.5, [ 0.5, 0.2, 0.5 ] )
+						.point( 1, [ 1, 0, 1 ] ) )
 					.toCanvas();
 
 
@@ -384,10 +384,10 @@
 			examples.push( function ( size ) {
 				var texture = new TG.Texture( size, size )
 					.add( new TG.RadialGradient().center( size / 2, 0 ).radius( size ).interpolation( 2 )
-						.point( 0, [ 1, 1, 0, 0 ] )
-						.point( 0.25, [ 0.2, 0, 0.5, 1 ] )
-						.point( 0.5, [ 0.5, 0.2, 0.5, 1 ] )
-						.point( 1, [ 1, 0, 1, 1 ] ) )
+						.point( 0, [ 1, 1, 0 ] )
+						.point( 0.25, [ 0.2, 0, 0.5 ] )
+						.point( 0.5, [ 0.5, 0.2, 0.5 ] )
+						.point( 1, [ 1, 0, 1 ] ) )
 					.toCanvas();
 
 
@@ -411,7 +411,7 @@
 				for ( i = 0; i <= numSamples; i++ ) {
 					var sample = new TG.Texture( size, size )
 					.set( new TG.PutTexture( base ) ) 		// copy the base texture, so that it doesn't get modified
-					.set( new TG.Transform().scale( 1 + 0.01 * i, 1 + 0.01 * i ).angle( 0.5 * i ) );		// modify the texture a bit more with each sample
+					.set( new TG.Transform().scale( 1 + 0.01 * i ).angle( 0.5 * i ) );		// modify the texture a bit more with each sample
 
 					blur.add( new TG.PutTexture( sample ) );		// adding the transformed sample to the result
 				}
@@ -439,12 +439,12 @@
 						.point( 0.4, [ 200, 15, 17 ] )		//[ 42, 166, 137 ]
 						.point( 0.6, [ 140, 49, 59 ] )		//[ 58, 131, 114 ]
 						.point( 0.8, [ 35, 10, 12 ] )		//[ 4, 46, 27 ]
-						.point( 1, [ 0, 0, 0 ] ) )
-					.div( new TG.Fill().tint( 255, 255, 255 ) );		// converting the 0-255 defined colors to the 0-1 space
+						.point( 1, 0 ) )
+					.div( new TG.Fill().tint( 255 ) );		// converting the 0-255 defined colors to the 0-1 space
 
 				var mirrored = new TG.Texture( size, size )
 					.add( new TG.PutTexture( pixel ).repeat( 2 ) )		// repeat the texture to get a cool mirrored pattern effect
-					.mul( new TG.PutTexture( vignette ).tint( 1.2, 1.2, 1.2 ) );		// adding the vignette from the example above
+					.mul( new TG.PutTexture( vignette ).tint( 1.2 ) );		// adding the vignette from the example above
 
 				var texture = mirrored.toCanvas();
 				

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,435 +1,434 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<title>texgen.js</title>
-		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-		<style>
-			body {
-				background-color: rgb(16, 18, 23);
-				color: rgb(200, 228, 255);
-				font-family: monospace;
-				font-size: 10pt;
-			}
-			
-			a {
-				color: rgb(110, 154, 181);
-			}
-			
-			a:visited {
-				color: rgb(110, 154, 181);
-			}
-			
-			canvas {
-				border: rgb(35, 41, 45) 1px solid;
-				margin: 10px 20px;
-			}
-			
-			#generated {
-				margin-top: 30px;
-				width: 100%;
-				text-align: center;
-			}
-			
-			canvas, pre {
-				display: inline-block;
-			}
-			
-			pre {
-				background: rgb(35, 41, 45);
-				margin-top: 10px;
-				padding: 10px;
-				
-				width: 60%;
-				overflow-x: auto;
-				
-				vertical-align: top;
-				text-align: left;
+<head>
+	<meta charset="utf-8">
+	<title>texgen.js</title>
+	<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+	<style>
+body {
+	background-color: rgb(16, 18, 23);
+	color: rgb(200, 228, 255);
+	font-family: monospace;
+	font-size: 10pt;
+}
 
-				/*-moz-tab-size: 4;
-				-o-tab-size:   4;
-				tab-size:      4;*/
-			}
-			
-			.cm-keyword { color: #d687a2; }
-			.cm-atom { color: #119a6c; }
-			.cm-number { color: #8b6194; }
-			.cm-def { color: #608ba7; }
-			.cm-variable { color: #a3bac1; }
-			.cm-property { color: #6f979a; } 
-			.cm-operator { color: #d08f64; }
-			.cm-variable-2 { color: #a3bac1; opacity: 0.8; }
-			.cm-variable-3 { color: #a3bac1; opacity: 0.6; }
-			.cm-comment { opacity: 0.25; }
-			.cm-string { color: #a05e55; }
-			.cm-string-2 { color: #964b40; }
+a {
+	color: rgb(110, 154, 181);
+}
 
-			.cm-error { color: #cc1d29; }
-			.cm-invalidchar { color: #cc1d29; }
-		</style>
+a:visited {
+	color: rgb(110, 154, 181);
+}
+
+canvas {
+	border: rgb(35, 41, 45) 1px solid;
+	margin: 10px 20px;
+}
+
+#generated {
+	margin-top: 30px;
+	width: 100%;
+	text-align: center;
+}
+
+canvas, pre {
+	display: inline-block;
+}
+
+pre {
+	background: rgb(35, 41, 45);
+	margin-top: 10px;
+	padding: 10px;
+	
+	width: 60%;
+	overflow-x: auto;
+	
+	vertical-align: top;
+	text-align: left;
+
+	/*-moz-tab-size: 4;
+	-o-tab-size:   4;
+	tab-size:      4;*/
+}
+
+.cm-keyword { color: #d687a2; }
+.cm-atom { color: #119a6c; }
+.cm-number { color: #8b6194; }
+.cm-def { color: #608ba7; }
+.cm-variable { color: #a3bac1; }
+.cm-property { color: #6f979a; } 
+.cm-operator { color: #d08f64; }
+.cm-variable-2 { color: #a3bac1; opacity: 0.8; }
+.cm-variable-3 { color: #a3bac1; opacity: 0.6; }
+.cm-comment { opacity: 0.25; }
+.cm-string { color: #a05e55; }
+.cm-string-2 { color: #964b40; }
+
+.cm-error { color: #cc1d29; }
+.cm-invalidchar { color: #cc1d29; }
+	</style>
+	
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/addon/runmode/runmode-standalone.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/javascript/javascript.min.js"></script>
+</head>
+<body>
+	<p>Change size: <a href="#128">128x128</a> <a href="#256">256x256</a> <a href="#512">512x512</a> <a id="customSize" href="javascript:void();">custom...</a></p>
+	
+	<div id="generated">
+	</div>
 		
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/addon/runmode/runmode-standalone.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/javascript/javascript.min.js"></script>
-	</head>
-	<body>
-		<p>Change size: <a href="#128">128x128</a> <a href="#256">256x256</a> <a href="#512">512x512</a> <a id="customSize" href="javascript:void();">custom...</a></p>
-		
-		<div id="generated">
-		</div>
-			
-		<!--<script src="../build/texgen.min.js"></script> -->
-		<script src="../src/TexGen.js"></script>
-		<script>
-			var generated = document.getElementById( "generated" );
-			var examples = [];
+	<!--<script src="../build/texgen.min.js"></script> -->
+	<script src="../src/TexGen.js"></script>
+	<script>
+var generated = document.getElementById( "generated" );
+var examples = [];
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.XOR().tint( 1, 0.5, 0.7 ) )',
-				'	.add( new TG.SinX().frequency( size / 2 ).tint( 0.25, 0, 0 ) )',
-				'	.sub( new TG.SinY().frequency( size / 2 ).tint( 0.25, 0, 0 ) )',
-				'	.add( new TG.SinX().frequency( size / 0.8 ).tint( 0.1, 0.5, 0.2 ) )',
-				'	.add( new TG.SinY().frequency( size / 0.8 ).tint( 0, 0.4, 0.5 ) )',
-				'	.add( new TG.Noise().tint( 0.1, 0.1, 0.2 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.XOR().tint( 1, 0.5, 0.7 ) )',
+	'	.add( new TG.SinX().frequency( size / 2 ).tint( 0.25, 0, 0 ) )',
+	'	.sub( new TG.SinY().frequency( size / 2 ).tint( 0.25, 0, 0 ) )',
+	'	.add( new TG.SinX().frequency( size / 0.8 ).tint( 0.1, 0.5, 0.2 ) )',
+	'	.add( new TG.SinY().frequency( size / 0.8 ).tint( 0, 0.4, 0.5 ) )',
+	'	.add( new TG.Noise().tint( 0.1, 0.1, 0.2 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.SinX().offset( size / 16 ).frequency( size / 3 ).tint( 0.1, 0.25, 0.5 ) )',
-				'	.add( new TG.SinY().offset( size / 16 ).frequency( size / 3 ).tint( 0.1, 0.25, 0.5 ) )',
-				'	.add( new TG.Fill().tint( 0.75, 0.5, 0.5 ) )',
-				'	.add( new TG.SinX().frequency( size / 3 ).tint( 0.2 ) )',
-				'	.add( new TG.SinY().frequency( size / 3 ).tint( 0.2 ) )',
-				'	.add( new TG.Noise().tint( 0.1, 0, 0 ) )',
-				'	.add( new TG.Noise().tint( 0, 0.1, 0 ) )',
-				'	.add( new TG.Noise().tint( 0, 0, 0.1 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.SinX().offset( size / 16 ).frequency( size / 3 ).tint( 0.1, 0.25, 0.5 ) )',
+	'	.add( new TG.SinY().offset( size / 16 ).frequency( size / 3 ).tint( 0.1, 0.25, 0.5 ) )',
+	'	.add( new TG.Fill().tint( 0.75, 0.5, 0.5 ) )',
+	'	.add( new TG.SinX().frequency( size / 3 ).tint( 0.2 ) )',
+	'	.add( new TG.SinY().frequency( size / 3 ).tint( 0.2 ) )',
+	'	.add( new TG.Noise().tint( 0.1, 0, 0 ) )',
+	'	.add( new TG.Noise().tint( 0, 0.1, 0 ) )',
+	'	.add( new TG.Noise().tint( 0, 0, 0.1 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.SinX().frequency( size / 12.8 ) )',
-				'	.mul( new TG.SinX().frequency( size / 6.4 ) )',
-				'	.mul( new TG.SinX().frequency( size / 3.2 ) )',
-				'	.mul( new TG.SinY().frequency( size / 12.8 ) )',
-				'	.mul( new TG.SinY().frequency( size / 6.4 ) )',
-				'	.mul( new TG.SinY().frequency( size / 3.2 ) )',
-				'	.add( new TG.SinX().frequency( size * 2 ).tint( -0.25, 0.1, 0.6 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.SinX().frequency( size / 12.8 ) )',
+	'	.mul( new TG.SinX().frequency( size / 6.4 ) )',
+	'	.mul( new TG.SinX().frequency( size / 3.2 ) )',
+	'	.mul( new TG.SinY().frequency( size / 12.8 ) )',
+	'	.mul( new TG.SinY().frequency( size / 6.4 ) )',
+	'	.mul( new TG.SinY().frequency( size / 3.2 ) )',
+	'	.add( new TG.SinX().frequency( size * 2 ).tint( -0.25, 0.1, 0.6 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.XOR() )',
-				'	.mul( new TG.OR().tint( 0.5, 0.8, 0.5 ) )',
-				'	.mul( new TG.SinX().frequency( 64 ) )',
-				'	.div( new TG.SinY().frequency( 64 ) )',
-				'	.add( new TG.SinX().frequency( 512 ).tint( 0.5, 0, 0 ) )',
-				'	.add( new TG.Noise().tint( 0.1, 0.1, 0.2 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.XOR() )',
+	'	.mul( new TG.OR().tint( 0.5, 0.8, 0.5 ) )',
+	'	.mul( new TG.SinX().frequency( 64 ) )',
+	'	.div( new TG.SinY().frequency( 64 ) )',
+	'	.add( new TG.SinX().frequency( 512 ).tint( 0.5, 0, 0 ) )',
+	'	.add( new TG.Noise().tint( 0.1, 0.1, 0.2 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.SinX().frequency( 2 / 0.01 ) )',
-				'	.mul( new TG.SinY().frequency( 2 / 0.0075 ) )',
-				'	.add( new TG.SinX().frequency( 2 / 0.0225 ) )',
-				'	.mul( new TG.SinY().frequency( 2 / 0.015 ) )',
-				'	.add( new TG.Noise().tint( 0.1, 0.1, 0.3 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.SinX().frequency( 2 / 0.01 ) )',
+	'	.mul( new TG.SinY().frequency( 2 / 0.0075 ) )',
+	'	.add( new TG.SinX().frequency( 2 / 0.0225 ) )',
+	'	.mul( new TG.SinY().frequency( 2 / 0.015 ) )',
+	'	.add( new TG.Noise().tint( 0.1, 0.1, 0.3 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.SinX().frequency( 40 ) )',
-				'	.mul( new TG.SinX().frequency( 25 ) )',
-				'	.add( new TG.SinY().frequency( 40 ) )',
-				'	.mul( new TG.SinY().frequency( 25 ) )',
-				'	.div( new TG.Fill().tint( 1, 2, 1 ) )',
-				'	.add( new TG.SinX().frequency( 1 / 0.003 ).tint( 0.5, 0, 0 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.SinX().frequency( 40 ) )',
+	'	.mul( new TG.SinX().frequency( 25 ) )',
+	'	.add( new TG.SinY().frequency( 40 ) )',
+	'	.mul( new TG.SinY().frequency( 25 ) )',
+	'	.div( new TG.Fill().tint( 1, 2, 1 ) )',
+	'	.add( new TG.SinX().frequency( 1 / 0.003 ).tint( 0.5, 0, 0 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.SinX().frequency( size / 8.6 ) )',
-				'	.add( new TG.SinY().frequency( size / 8.6 ) )',
-				'	.mul( new TG.SinX().offset( -32 ).frequency( size / 6.4 ).tint( 2 ) )',
-				'	.mul( new TG.SinY().offset( -16 ).frequency( size / 6.4 ).tint( 2 ) )',
-				'	.sub( new TG.Fill().tint( 0.5, 2, 4 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.SinX().frequency( size / 8.6 ) )',
+	'	.add( new TG.SinY().frequency( size / 8.6 ) )',
+	'	.mul( new TG.SinX().offset( -32 ).frequency( size / 6.4 ).tint( 2 ) )',
+	'	.mul( new TG.SinY().offset( -16 ).frequency( size / 6.4 ).tint( 2 ) )',
+	'	.sub( new TG.Fill().tint( 0.5, 2, 4 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.SinX().frequency( size * 2 ) )',
-				'	.mul( new TG.SinY().frequency( size * 2 ) )',
-				'	.mul( new TG.SinY().offset( -size / 8 ).frequency( size / 2 ) )',
-				'	.div( new TG.SinX().frequency( size / 2 ).tint( 8, 5, 4 ) )',
-				'	.add( new TG.Noise().tint( 0.1, 0, 0 ) )',
-				'	.add( new TG.Noise().tint( 0, 0.1, 0 ) )',
-				'	.add( new TG.Noise().tint( 0, 0, 0.1 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.SinX().frequency( size * 2 ) )',
+	'	.mul( new TG.SinY().frequency( size * 2 ) )',
+	'	.mul( new TG.SinY().offset( -size / 8 ).frequency( size / 2 ) )',
+	'	.div( new TG.SinX().frequency( size / 2 ).tint( 8, 5, 4 ) )',
+	'	.add( new TG.Noise().tint( 0.1, 0, 0 ) )',
+	'	.add( new TG.Noise().tint( 0, 0.1, 0 ) )',
+	'	.add( new TG.Noise().tint( 0, 0, 0.1 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.CheckerBoard() )',
-				'	.add( new TG.CheckerBoard().size( 2 ).tint( 0.5, 0, 0 ) )',
-				'	.add( new TG.CheckerBoard().size( 8 ).tint( 1, 0.5, 0.5 ) )',
-				'	.sub( new TG.CheckerBoard().offset( -16, -16 ).tint( 0.5, 0.5, 0 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.CheckerBoard() )',
+	'	.add( new TG.CheckerBoard().size( 2 ).tint( 0.5, 0, 0 ) )',
+	'	.add( new TG.CheckerBoard().size( 8 ).tint( 1, 0.5, 0.5 ) )',
+	'	.sub( new TG.CheckerBoard().offset( -16, -16 ).tint( 0.5, 0.5, 0 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.Rect().position( size / 4.8, size / 12 ).size( size / 1.7, size / 2 ).tint( 1, 0.25, 0.25 ) )',
-				'	.add( new TG.Rect().position( size / 12, size / 4 ).size( size / 1.21, size / 2 ).tint( 0.25, 1, 0.25 ) )',
-				'	.add( new TG.Rect().position( size / 4.8, size / 2.5 ).size( size / 1.7, size / 2 ).tint( 0.25, 0.25, 1 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.Rect().position( size / 4.8, size / 12 ).size( size / 1.7, size / 2 ).tint( 1, 0.25, 0.25 ) )',
+	'	.add( new TG.Rect().position( size / 12, size / 4 ).size( size / 1.21, size / 2 ).tint( 0.25, 1, 0.25 ) )',
+	'	.add( new TG.Rect().position( size / 4.8, size / 2.5 ).size( size / 1.7, size / 2 ).tint( 0.25, 0.25, 1 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.CheckerBoard().size( 32 ).tint( 0.5, 0, 0 ) )',
-				'	.set( new TG.SineDistort() )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.CheckerBoard().size( 32 ).tint( 0.5, 0, 0 ) )',
+	'	.set( new TG.SineDistort() )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.CheckerBoard().size( 32 ).tint( 0.5, 0, 0 ) )',
-				'	.set( new TG.Twirl().radius( size / 2 ).position( size / 2, size / 2 ).strength ( 75 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.CheckerBoard().size( 32 ).tint( 0.5, 0, 0 ) )',
+	'	.set( new TG.Twirl().radius( size / 2 ).position( size / 2, size / 2 ).strength ( 75 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.Circle().position( size / 2, size / 2 ).radius( size / 4 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.Circle().position( size / 2, size / 2 ).radius( size / 4 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.Circle().position( size / 2, size / 2 ).radius( size / 4 ).delta( size / 4 ).tint( 1, 0.25, 0.25 ) )',
-				'	.set( new TG.Pixelate().size( size / 32 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.Circle().position( size / 2, size / 2 ).radius( size / 4 ).delta( size / 4 ).tint( 1, 0.25, 0.25 ) )',
+	'	.set( new TG.Pixelate().size( size / 32 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.CheckerBoard().tint( 1, 1, 0 ) )',
-				'	.set( new TG.Transform().offset( 10, 20 ).angle( 23 ).scale( 2, 0.5 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.CheckerBoard().tint( 1, 1, 0 ) )',
+	'	.set( new TG.Transform().offset( 10, 20 ).angle( 23 ).scale( 2, 0.5 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.CheckerBoard() )',
-				'	.and( new TG.Circle().position( size / 2, size / 2 ).radius( size / 3 ) )',
-				'	.xor( new TG.Circle().position( size / 2, size / 2 ).radius( size / 4 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.CheckerBoard() )',
+	'	.and( new TG.Circle().position( size / 2, size / 2 ).radius( size / 3 ) )',
+	'	.xor( new TG.Circle().position( size / 2, size / 2 ).radius( size / 4 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.CheckerBoard().size( size / 16 ) )',
-				'	.set( new TG.Twirl().radius( size / 2 ).strength( 75 ).position( size / 2, size / 2 ) )',
-				'	.min( new TG.Circle().position( size / 2, size / 2 ).radius( size / 2 ).delta( size / 2 ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.CheckerBoard().size( size / 16 ) )',
+	'	.set( new TG.Twirl().radius( size / 2 ).strength( 75 ).position( size / 2, size / 2 ) )',
+	'	.min( new TG.Circle().position( size / 2, size / 2 ).radius( size / 2 ).delta( size / 2 ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.LinearGradient().interpolation( 0 )',
-				'		.point( 0, [ 1, 1, 0 ] )',
-				'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
-				'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
-				'		.point( 1, [ 1, 0, 1 ] ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.LinearGradient().interpolation( 0 )',
+	'		.point( 0, [ 1, 1, 0 ] )',
+	'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
+	'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
+	'		.point( 1, [ 1, 0, 1 ] ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.LinearGradient().interpolation( 1 )',
-				'		.point( 0, [ 1, 1, 0 ] )',
-				'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
-				'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
-				'		.point( 1, [ 1, 0, 1 ] ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.LinearGradient().interpolation( 1 )',
+	'		.point( 0, [ 1, 1, 0 ] )',
+	'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
+	'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
+	'		.point( 1, [ 1, 0, 1 ] ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.LinearGradient().interpolation( 2 )',
-				'		.point( 0, [ 1, 1, 0 ] )',
-				'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
-				'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
-				'		.point( 1, [ 1, 0, 1 ] ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.LinearGradient().interpolation( 2 )',
+	'		.point( 0, [ 1, 1, 0 ] )',
+	'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
+	'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
+	'		.point( 1, [ 1, 0, 1 ] ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.RadialGradient().center( size / 2, size / 2 ).radius( size / 8 ).repeat( true ).interpolation( 0 )',
-				'		.point( 0, [ 1, 1, 0 ] )',
-				'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
-				'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
-				'		.point( 1, [ 1, 0, 1 ] ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.RadialGradient().center( size / 2, size / 2 ).radius( size / 8 ).repeat( true ).interpolation( 0 )',
+	'		.point( 0, [ 1, 1, 0 ] )',
+	'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
+	'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
+	'		.point( 1, [ 1, 0, 1 ] ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.RadialGradient().center( 0, 0 ).radius( size * 2 ).interpolation( 1 )',
-				'		.point( 0, [ 1, 1, 0 ] )',
-				'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
-				'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
-				'		.point( 1, [ 1, 0, 1 ] ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.RadialGradient().center( 0, 0 ).radius( size * 2 ).interpolation( 1 )',
+	'		.point( 0, [ 1, 1, 0 ] )',
+	'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
+	'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
+	'		.point( 1, [ 1, 0, 1 ] ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//
+//
 
-			examples.push([
-				'var texture = new TG.Texture( size, size )',
-				'	.add( new TG.RadialGradient().center( size / 2, 0 ).radius( size ).interpolation( 2 )',
-				'		.point( 0, [ 1, 1, 0 ] )',
-				'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
-				'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
-				'		.point( 1, [ 1, 0, 1 ] ) )',
-				'	.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'var texture = new TG.Texture( size, size )',
+	'	.add( new TG.RadialGradient().center( size / 2, 0 ).radius( size ).interpolation( 2 )',
+	'		.point( 0, [ 1, 1, 0 ] )',
+	'		.point( 0.25, [ 0.2, 0, 0.5 ] )',
+	'		.point( 0.5, [ 0.5, 0.2, 0.5 ] )',
+	'		.point( 1, [ 1, 0, 1 ] ) )',
+	'	.toCanvas();'
+].join( "\n" ));
 
-			//---- Put-Texture ----
+//---- Put-Texture ----
 
-			examples.push([
-				'vignette = new TG.Texture( size, size )		// predefine a vignette-effect so it can be used later',
-				'	.set( new TG.Circle().radius( size ).position( size / 2, size / 2 ).delta( size * 0.7 ) );',
-				'	',
-				'var numSamples = 6;		// more samples = heavier effect',
-				'',
-				'var base = new TG.Texture( size, size )		// generating an image to be blurred',
-				'	.set( new TG.FractalNoise().amplitude( 0.46 ).persistence( 0.78 ).interpolation( 0 ) )',
-				'	.set( new TG.Normalize() );',
-				'',
-				'var blur = new TG.Texture( size, size );		// the texture the samples are put onto',
-				'',
-				'for ( i = 0; i <= numSamples; i++ ) {',
-				'	var sample = new TG.Texture( size, size )',
-				'	.set( new TG.PutTexture( base ) ) 		// copy the base texture, so that it doesn\'t get modified',
-				'	.set( new TG.Transform().scale( 1 + 0.01 * i ).angle( 0.5 * i ) );		// modify the texture a bit more with each sample',
-				'',
-				'	blur.add( new TG.PutTexture( sample ) );		// adding the transformed sample to the result',
-				'}',
-				'',
-				'blur.set( new TG.Normalize() )		// since the samples are not weighted, put everything in the visible range',
-				'	.mul( new TG.PutTexture( vignette ) );		// adding the predefined vignette-effect',
-				'',
-				'base.toCanvas();		// since we copied the base texture instead of modifying it directly, we can still use it how it was before',
-				'',
-				'var texture = blur.toCanvas();'
-			].join( "\n" ));
+examples.push([
+	'vignette = new TG.Texture( size, size )		// predefine a vignette-effect so it can be used later',
+	'	.set( new TG.Circle().radius( size ).position( size / 2, size / 2 ).delta( size * 0.7 ) );',
+	'	',
+	'var numSamples = 6;		// more samples = heavier effect',
+	'',
+	'var base = new TG.Texture( size, size )		// generating an image to be blurred',
+	'	.set( new TG.FractalNoise().amplitude( 0.46 ).persistence( 0.78 ).interpolation( 0 ) )',
+	'	.set( new TG.Normalize() );',
+	'',
+	'var blur = new TG.Texture( size, size );		// the texture the samples are put onto',
+	'',
+	'for ( i = 0; i <= numSamples; i++ ) {',
+	'	var sample = new TG.Texture( size, size )',
+	'	.set( new TG.PutTexture( base ) ) 		// copy the base texture, so that it doesn\'t get modified',
+	'	.set( new TG.Transform().scale( 1 + 0.01 * i ).angle( 0.5 * i ) );		// modify the texture a bit more with each sample',
+	'',
+	'	blur.add( new TG.PutTexture( sample ) );		// adding the transformed sample to the result',
+	'}',
+	'',
+	'blur.set( new TG.Normalize() )		// since the samples are not weighted, put everything in the visible range',
+	'	.mul( new TG.PutTexture( vignette ) );		// adding the predefined vignette-effect',
+	'',
+	'base.toCanvas();		// since we copied the base texture instead of modifying it directly, we can still use it how it was before',
+	'',
+	'var texture = blur.toCanvas();'
+].join( "\n" ));
 
-			//----
+//----
 
-			examples.push([
-				'var subDim = Math.floor( size / 4 );		// generate a smaller image so it can be mirrored later',
-				'',
-				'var pixel = new TG.Texture( subDim, subDim )',
-				'	.set( new TG.FractalNoise().baseFrequency( subDim / 15 ).octaves( 1 ).amplitude( 1 ) )		// generating a noise pattern with 15 pixels per length',
-				'	.set( new TG.GradientMap().interpolation( 0 )		// divide the generated values into defined colors',
-				'		.point( 0, [ 250, 230, 210 ] )		//[ 251, 255, 228 ] (alternative colors)',
-				'		.point( 0.2, [ 255, 92, 103 ] )		//[ 130, 198, 184 ]',
-				'		.point( 0.4, [ 200, 15, 17 ] )		//[ 42, 166, 137 ]',
-				'		.point( 0.6, [ 140, 49, 59 ] )		//[ 58, 131, 114 ]',
-				'		.point( 0.8, [ 35, 10, 12 ] )		//[ 4, 46, 27 ]',
-				'		.point( 1, 0 ) )',
-				'	.div( new TG.Fill().tint( 255 ) );		// converting the 0-255 defined colors to the 0-1 space',
-				'',
-				'var mirrored = new TG.Texture( size, size )',
-				'	.add( new TG.PutTexture( pixel ).repeat( 2 ) )		// repeat the texture to get a cool mirrored pattern effect',
-				'	.mul( new TG.PutTexture( vignette ).tint( 1.2 ) );		// adding the vignette from the example above',
-				'',
-				'var texture = mirrored.toCanvas();'
-			].join( "\n" ));
-			
-			//----------------
-			
-			function generateTexture ( a ) {
-				if ( a >= examples.length ) return;
-			
-				var div = document.createElement( "div" );
-				var source = document.createElement( "pre" );
-				
-				CodeMirror.runMode(examples[ a ], "javascript", source);
-				
-				var func = new Function("size", examples[ a ] + "\nreturn texture;") 
-				div.appendChild( func( s ) );
-				div.appendChild( source );
-				generated.appendChild( div );
-				generated.appendChild( document.createElement( "br" ) );
-				
-				setTimeout( function () { generateTexture( a + 1 ); } )
-			};
-			
-			var s = ( window.location.hash ) ? parseInt( window.location.hash.substring( 1 ), 10 ) : 256;
-			setTimeout( function () { generateTexture(0); } );
+examples.push([
+	'var subDim = Math.floor( size / 4 );		// generate a smaller image so it can be mirrored later',
+	'',
+	'var pixel = new TG.Texture( subDim, subDim )',
+	'	.set( new TG.FractalNoise().baseFrequency( subDim / 15 ).octaves( 1 ).amplitude( 1 ) )		// generating a noise pattern with 15 pixels per length',
+	'	.set( new TG.GradientMap().interpolation( 0 )		// divide the generated values into defined colors',
+	'		.point( 0, [ 250, 230, 210 ] )		//[ 251, 255, 228 ] (alternative colors)',
+	'		.point( 0.2, [ 255, 92, 103 ] )		//[ 130, 198, 184 ]',
+	'		.point( 0.4, [ 200, 15, 17 ] )		//[ 42, 166, 137 ]',
+	'		.point( 0.6, [ 140, 49, 59 ] )		//[ 58, 131, 114 ]',
+	'		.point( 0.8, [ 35, 10, 12 ] )		//[ 4, 46, 27 ]',
+	'		.point( 1, 0 ) )',
+	'	.div( new TG.Fill().tint( 255 ) );		// converting the 0-255 defined colors to the 0-1 space',
+	'',
+	'var mirrored = new TG.Texture( size, size )',
+	'	.add( new TG.PutTexture( pixel ).repeat( 2 ) )		// repeat the texture to get a cool mirrored pattern effect',
+	'	.mul( new TG.PutTexture( vignette ).tint( 1.2 ) );		// adding the vignette from the example above',
+	'',
+	'var texture = mirrored.toCanvas();'
+].join( "\n" ));
 
-			window.addEventListener( "hashchange", function () { 
-				window.location.reload();
-			});
+//----------------
 
-			document.getElementById("customSize").addEventListener("click", function () {
-				newSize = prompt("Size in pixel:", 256);
-				
-				if ( newSize ) window.location.hash = newSize;
-			});
-		
-		</script>
-	</body>
+function generateTexture ( a ) {
+	if ( a >= examples.length ) return;
+
+	var div = document.createElement( "div" );
+	var source = document.createElement( "pre" );
+	
+	CodeMirror.runMode(examples[ a ], "javascript", source);
+	
+	var func = new Function("size", examples[ a ] + "\nreturn texture;") 
+	div.appendChild( func( s ) );
+	div.appendChild( source );
+	generated.appendChild( div );
+	generated.appendChild( document.createElement( "br" ) );
+	
+	setTimeout( function () { generateTexture( a + 1 ); } )
+};
+
+var s = ( window.location.hash ) ? parseInt( window.location.hash.substring( 1 ), 10 ) : 256;
+setTimeout( function () { generateTexture(0); } );
+
+window.addEventListener( "hashchange", function () { 
+	window.location.reload();
+});
+
+document.getElementById("customSize").addEventListener("click", function () {
+	newSize = prompt("Size in pixel:", 256);
+	
+	if ( newSize ) window.location.hash = newSize;
+});
+	</script>
+</body>
 </html>
 

--- a/examples/noise.html
+++ b/examples/noise.html
@@ -190,21 +190,21 @@
 				new TG.Texture(size, size)
 					.set(new TG.FractalNoise().baseFrequency(64).octaves(6).step(2).interpolation(2) )
 					.sub(new TG.Noise().tint(0, 0.1, 0) )
-					.min(new TG.Number().tint(0, 0.6, 0) )
-					.sub(new TG.Number().tint(0, 0.5, 0) )
-					.mul(new TG.Number().tint(0, 5, 0) )
+					.min(new TG.Fill().tint(0, 0.6, 0) )
+					.sub(new TG.Fill().tint(0, 0.5, 0) )
+					.mul(new TG.Fill().tint(0, 5, 0) )
 					.sub(new TG.SineDistort().sines(2, 2).amplitude(8, 8).tint(0, 0.75, 0) )
-					.add(new TG.Number().tint(0.06, 0, 0.085) )
+					.add(new TG.Fill().tint(0.06, 0, 0.085) )
 					.addToPage("Example 2");
 
 				new TG.Texture(size, size)
 					.set(new TG.FractalNoise().baseFrequency(128).octaves(6).step(2).interpolation(2) )
 					.sub(new TG.Noise().tint(0, 0.1, 0) )
-					.min(new TG.Number().tint(0, 0.63, 0) )
-					.sub(new TG.Number().tint(0, 0.53, 0) )
-					.mul(new TG.Number().tint(0, 6, 0) )
+					.min(new TG.Fill().tint(0, 0.63, 0) )
+					.sub(new TG.Fill().tint(0, 0.53, 0) )
+					.mul(new TG.Fill().tint(0, 6, 0) )
 					.sub(new TG.SineDistort().sines(2, 2).amplitude(4, 4).tint(0, 0.75, 0) )
-					.add(new TG.Number().tint(0.065, 0, 0.095) )
+					.add(new TG.Fill().tint(0.065, 0, 0.095) )
 					.addToPage("Example 2 (less distortion)");
 
 				line = document.createElement("br");

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -122,6 +122,7 @@ TG.ColorInterpolatorMethod = {
 	STEP: 0,
 	LINEAR: 1,
 	SPLINE: 2,
+	COSINE: 3,
 };
 
 TG.ColorInterpolator = function( method ) {
@@ -223,6 +224,15 @@ TG.ColorInterpolator.prototype = {
 				ar * delta3 + br * delta2 + dr,
 				ag * delta3 + bg * delta2 + dg,
 				ab * delta3 + bb * delta2 + db
+			];
+
+		} else if ( this.interpolation == TG.ColorInterpolatorMethod.COSINE ) {
+			var cos = (1 - Math.cos(delta * Math.PI)) / 2;
+
+			return [
+				( p1.color[ 0 ] * ( 1 - cos ) ) + ( p2.color[ 0 ] * cos ),
+				( p1.color[ 1 ] * ( 1 - cos ) ) + ( p2.color[ 1 ] * cos ),
+				( p1.color[ 2 ] * ( 1 - cos ) ) + ( p2.color[ 2 ] * cos ),
 			];
 
 		}

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -502,11 +502,11 @@ TG.SinX = function () {
 
 	return new TG.Program( {
 		frequency: function ( value ) {
-			params.frequency = value * Math.PI;
+			params.frequency = ( 2 / value ) * Math.PI;
 			return this;
 		},
 		offset: function ( value ) {
-			params.offset = value;
+			params.offset = -value;
 			return this;
 		},
 		getParams: function () {
@@ -533,11 +533,11 @@ TG.SinY = function () {
 
 	return new TG.Program( {
 		frequency: function ( value ) {
-			params.frequency = value * Math.PI;
+			params.frequency = ( 2 / value ) * Math.PI;
 			return this;
 		},
 		offset: function ( value ) {
-			params.offset = value;
+			params.offset = -value;
 			return this;
 		},
 		getParams: function () {
@@ -950,7 +950,7 @@ TG.CheckerBoard = function () {
 			return this;
 		},
 		offset: function ( x, y ) {
-			params.offset = [ x, y ];
+			params.offset = [ -x, -y ];
 			return this;
 		},
 		rowShift: function ( value ) {
@@ -1272,7 +1272,7 @@ TG.Transform = function () {
 
 	return new TG.Program( {
 		offset: function ( x, y ) {
-			params.offset = [ x, y ];
+			params.offset = [ -x, -y ];
 			return this;
 		},
 		angle: function ( value ) {

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -341,7 +341,8 @@ TG.OP = {
 	AND: function ( x, y ) { return x & y; },
 	XOR: function ( x, y ) { return x ^ y; },
 	MIN: function ( x, y ) { return Math.min( x, y ); },
-	MAX: function ( x, y ) { return Math.max( x, y ); }
+	MAX: function ( x, y ) { return Math.max( x, y ); },
+	POW: function ( x, y ) { return Math.pow( x, y ); }
 };
 
 TG.Texture = function ( width, height ) {
@@ -397,6 +398,8 @@ TG.Texture.prototype = {
 	min: function ( program ) { return this.set( program, TG.OP.MIN ); },
 
 	max: function ( program ) { return this.set( program, TG.OP.MAX ); },
+
+	pow: function ( program ) { return this.set( program, TG.OP.POW ); },
 
 	toImageData: function ( context ) {
 

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -478,7 +478,7 @@ TG.Program = function ( object ) {
 
 // --- Generators ---
 
-TG.Number = function () {
+TG.Fill = function () {
 
 	return new TG.Program( {
 		getParams: function () {},

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -461,7 +461,7 @@ TG.Program = function ( object ) {
 
 	var tint = new Float32Array( [ 1, 1, 1 ] );
 
-	object.tint = function ( r, g, b ) {
+	object.tint = function ( r, g, b ) { 		// multiplies each color channel of the generated image by 'r', 'g' and 'b' respectively
 		tint[ 0 ] = r;
 		tint[ 1 ] = ( typeof g == 'undefined' ) ? r : g;
 		tint[ 2 ] = ( typeof b == 'undefined' ) ? r : b;
@@ -478,7 +478,7 @@ TG.Program = function ( object ) {
 
 // --- Generators ---
 
-TG.Fill = function () {
+TG.Fill = function () { 		// every pixel set to 1; together with tint can be used to do basic calculations (e.g. .mul( TG.Fill().tint( 2 ) ) -> double the value of each pixel)
 
 	return new TG.Program( {
 		getParams: function () {},
@@ -493,7 +493,7 @@ TG.Fill = function () {
 
 };
 
-TG.SinX = function () {
+TG.SinX = function () { 		// generates a sine wave on the x and value (brightness) axes
 
 	var params = {
 		frequency: 1,
@@ -501,11 +501,11 @@ TG.SinX = function () {
 	};
 
 	return new TG.Program( {
-		frequency: function ( value ) {
+		frequency: function ( value ) { 		// sets the 'width' of the sine wave in pixels
 			params.frequency = ( 2 / value ) * Math.PI;
 			return this;
 		},
-		offset: function ( value ) {
+		offset: function ( value ) { 		// moves the wave by 'value' pixels
 			params.offset = -value;
 			return this;
 		},
@@ -524,7 +524,7 @@ TG.SinX = function () {
 
 };
 
-TG.SinY = function () {
+TG.SinY = function () { 		// generates a sine wave on the y and value (brightness) axes
 
 	var params = {
 		frequency: 1,
@@ -532,11 +532,11 @@ TG.SinY = function () {
 	};
 
 	return new TG.Program( {
-		frequency: function ( value ) {
+		frequency: function ( value ) { 		// sets the 'width' of the sine wave in pixels
 			params.frequency = ( 2 / value ) * Math.PI;
 			return this;
 		},
-		offset: function ( value ) {
+		offset: function ( value ) { 		// moves the wave by 'value' pixels
 			params.offset = -value;
 			return this;
 		},
@@ -555,7 +555,7 @@ TG.SinY = function () {
 
 };
 
-TG.OR = function () {
+TG.OR = function () { 		// generates a pattern using bitwise OR on the x and y coordinates
 
 	return new TG.Program( {
 		getParams: function () {},
@@ -571,7 +571,7 @@ TG.OR = function () {
 
 };
 
-TG.XOR = function () {
+TG.XOR = function () { 		// generates a pattern using bitwise XOR on the x and y coordinates
 
 	return new TG.Program( {
 		getParams: function () {},
@@ -587,7 +587,7 @@ TG.XOR = function () {
 
 };
 
-TG.Noise = function () {
+TG.Noise = function () { 		// generates a random noise pattern
 
 	var params = {
 		seed: TG.Utils.globalSeed++,
@@ -595,11 +595,11 @@ TG.Noise = function () {
 	};
 
 	return new TG.Program( {
-		seed: function ( value ) {
+		seed: function ( value ) { 		// the same seed always results in the same noise pattern
 			params.seed = value;
 			return this;
 		},
-		size: function ( value ) {
+		size: function ( value ) { 		// sets the size of the pixel grid for the noise function
 			params.size = value;
 			return this;
 		},
@@ -618,7 +618,7 @@ TG.Noise = function () {
 
 };
 
-TG.FractalNoise = function () {
+TG.FractalNoise = function () { 		// generates a noise pattern with extra 'depth' by overlaying noise of different sizes
 
 	var params = {
 		interpolator: new TG.ColorInterpolator( TG.ColorInterpolatorMethod.STEP ),
@@ -631,31 +631,31 @@ TG.FractalNoise = function () {
 	};
 
 	return new TG.Program( {
-		seed: function ( value ) {
+		seed: function ( value ) { 		// the same seed always results in the same noise pattern
 			params.seed = value;
 			return this;
 		},
-		baseFrequency: function ( value ) {
+		baseFrequency: function ( value ) { 		// sets the size of the noise for the first octave in pixels
 			params.baseFrequency = 1 / value;
 			return this;
 		},
-		amplitude: function ( value ) {
+		amplitude: function ( value ) { 		// sets how much 'contrast' the noise should initially have; gets decreased with each octave
 			params.amplitude = value;
 			return this;
 		},
-		persistence: function ( value ) {
+		persistence: function ( value ) { 		// how much the amplitude should be decreased with each octave
 			params.persistence = value;
 			return this;
 		},
-		octaves: function ( value ) {
+		octaves: function ( value ) { 		// how many different noise patterns are layered on top of each other
 			params.octaves = Math.max( 1, value );
 			return this;
 		},
-		step: function ( value ) {
+		step: function ( value ) { 		// how much the frequency gets decreased with each octave (e.g. a value of 2 halves the size each time)
 			params.step = Math.max( 0, value );
 			return this;
 		},
-		interpolation: function ( value ) {
+		interpolation: function ( value ) { 		// which interpolation algorithm should be used for non-whole coordinates -> should the noise be smooth or rough? (see TG.ColorInterpolator below)
 			params.interpolator.setInterpolation( value );
 			return this;
 		},
@@ -719,7 +719,7 @@ TG.FractalNoise = function () {
 
 };
 
-TG.CellularNoise = function () {
+TG.CellularNoise = function () { 		// noise based on the distance of randomly distributed points on the xy-plane
 
 	var params = {
 		seed: TG.Utils.globalSeed++,
@@ -728,15 +728,15 @@ TG.CellularNoise = function () {
 	};
 
 	return new TG.Program( {
-		seed: function ( value ) {
+		seed: function ( value ) { 		// the same seed always results in the same noise pattern
 			params.seed = value;
 			return this;
 		},
-		density: function ( value ) {
+		density: function ( value ) { 		// the average distance betweeen each point in pixels; negative values invert the pattern
 			params.density = value;
 			return this;
 		},
-		weightRange: function ( value ) {
+		weightRange: function ( value ) { 		// gives some points more or less 'influence' making them bigger or smaller; too high values can break the point finding algorithm!
 			params.weightRange = Math.max( 0, value );
 			return this;
 		},
@@ -759,7 +759,7 @@ TG.CellularNoise = function () {
 
 };
 
-TG.VoronoiNoise = function () {
+TG.VoronoiNoise = function () { 		// noise based on voronoi diagrams of randomly distributed points on the xy-plane
 
 	var params = {
 		seed: TG.Utils.globalSeed++,
@@ -768,15 +768,15 @@ TG.VoronoiNoise = function () {
 	};
 
 	return new TG.Program( {
-		seed: function ( value ) {
+		seed: function ( value ) { 		// the same seed always results in the same noise pattern
 			params.seed = value;
 			return this;
 		},
-		density: function ( value ) {
+		density: function ( value ) { 		// the average distance betweeen each point in pixels
 			params.density = value;
 			return this;
 		},
-		weightRange: function ( value ) {
+		weightRange: function ( value ) { 		// gives some points more or less 'influence'; too high values can break the point finding algorithm!
 			params.weightRange = Math.max( 0, value );
 			return this;
 		},
@@ -796,7 +796,7 @@ TG.VoronoiNoise = function () {
 
 };
 
-TG.CellularFractal = function () {
+TG.CellularFractal = function () { 		// generates a noise pattern with extra 'depth' by overlaying cellular noise with different densities
 
 	var params = {
 		seed: TG.Utils.globalSeed++,
@@ -809,31 +809,31 @@ TG.CellularFractal = function () {
 	};
 
 	return new TG.Program( {
-		seed: function ( value ) {
+		seed: function ( value ) { 		// the same seed always results in the same noise pattern
 			params.seed = value;
 			return this;
 		},
-		baseDensity: function ( value ) {
+		baseDensity: function ( value ) { 		// sets the density for the first octave
 			params.baseDensity = value;
 			return this;
 		},
-		weightRange: function ( value ) {
+		weightRange: function ( value ) { 		// sets the weightRange for the cellular noise; see TG.CellularNoise above
 			params.weightRange = Math.max( 0, value );
 			return this;
 		},
-		amplitude: function ( value ) {
+		amplitude: function ( value ) { 		// sets how much 'contrast' the noise should initially have; gets decreased with each octave
 			params.amplitude = value;
 			return this;
 		},
-		persistence: function ( value ) {
+		persistence: function ( value ) { 		// how much the amplitude should be decreased with each octave
 			params.persistence = value;
 			return this;
 		},
-		octaves: function ( value ) {
+		octaves: function ( value ) { 		// how many different noise patterns are layered on top of each other
 			params.octaves = Math.max( 1, value );
 			return this;
 		},
-		step: function ( value ) {
+		step: function ( value ) { 		// how much the density gets decreased with each octave (e.g. a value of 2 halves the density each time)
 			params.step = Math.max( 1, value );
 			return this;
 		},
@@ -867,7 +867,7 @@ TG.CellularFractal = function () {
 
 };
 
-TG.VoronoiFractal = function () {
+TG.VoronoiFractal = function () { 		// generates a noise pattern with extra 'depth' by overlaying voronoi noise with different densities
 
 	var params = {
 		seed: TG.Utils.globalSeed++,
@@ -880,31 +880,31 @@ TG.VoronoiFractal = function () {
 	};
 
 	return new TG.Program( {
-		seed: function ( value ) {
+		seed: function ( value ) { 		// the same seed always results in the same noise pattern
 			params.seed = value;
 			return this;
 		},
-		baseDensity: function ( value ) {
+		baseDensity: function ( value ) { 		// sets the density for the first octave
 			params.baseDensity = value;
 			return this;
 		},
-		weightRange: function ( value ) {
+		weightRange: function ( value ) { 		// sets the weightRange for the voronoi noise; see TG.VoronoiNoise above
 			params.weightRange = Math.max( 0, value );
 			return this;
 		},
-		amplitude: function ( value ) {
+		amplitude: function ( value ) { 		// sets how much 'contrast' the noise should initially have; gets decreased with each octave
 			params.amplitude = value;
 			return this;
 		},
-		persistence: function ( value ) {
+		persistence: function ( value ) { 		// how much the amplitude should be decreased with each octave (values over 1 increase the amplitude instead)
 			params.persistence = value;
 			return this;
 		},
-		octaves: function ( value ) {
+		octaves: function ( value ) { 		// how many different noise patterns are layered on top of each other
 			params.octaves = Math.max( 1, value );
 			return this;
 		},
-		step: function ( value ) {
+		step: function ( value ) { 		// how much the density gets decreased with each octave (e.g. a value of 2 halves the density each time)
 			params.step = Math.max( 1, value );
 			return this;
 		},
@@ -935,7 +935,7 @@ TG.VoronoiFractal = function () {
 
 };
 
-TG.CheckerBoard = function () {
+TG.CheckerBoard = function () { 		// generates a grid pattern of alternating black and white cells
 
 	var params = {
 		size: [ 32, 32 ],
@@ -944,16 +944,16 @@ TG.CheckerBoard = function () {
 	};
 
 	return new TG.Program( {
-		size: function ( x, y ) {
+		size: function ( x, y ) { 		// sets the width and height of each square in pixels
 			if ( typeof y == "undefined" ) y = x;
 			params.size = [ x, y ];
 			return this;
 		},
-		offset: function ( x, y ) {
+		offset: function ( x, y ) { 		// moves the origin of the pattern to 'x' and 'y' in pixels
 			params.offset = [ -x, -y ];
 			return this;
 		},
-		rowShift: function ( value ) {
+		rowShift: function ( value ) { 		// offsets each row by 'value' pixels
 			params.rowShift = value;
 			return this;
 		},
@@ -972,7 +972,7 @@ TG.CheckerBoard = function () {
 
 };
 
-TG.Rect = function () {
+TG.Rect = function () { 		// generates a basic white rectangle
 
 	var params = {
 		position: [ 0, 0 ],
@@ -980,11 +980,11 @@ TG.Rect = function () {
 	};
 
 	return new TG.Program( {
-		position: function ( x, y ) {
+		position: function ( x, y ) { 		// sets the coordinates of the top-leftmost point of the rectangle
 			params.position = [ x, y ];
 			return this;
 		},
-		size: function ( x, y ) {
+		size: function ( x, y ) { 		// sets the width and height of the rectangle
 			if ( typeof y == "undefined" ) y = x;
 			params.size = [ x, y ];
 			return this;
@@ -1004,7 +1004,7 @@ TG.Rect = function () {
 
 };
 
-TG.Circle = function () {
+TG.Circle = function () { 		// generates a basic white circle
 
 	var params = {
 		position: [ 0, 0 ],
@@ -1013,15 +1013,15 @@ TG.Circle = function () {
 	};
 
 	return new TG.Program( {
-		delta: function ( value ) {
+		delta: function ( value ) { 		// sets how many pixels from the edge of the circle the brightness should gradually decrease; 0 results in a completely crisp circle
 			params.delta = value;
 			return this;
 		},
-		position: function ( x, y ) {
+		position: function ( x, y ) { 		// sets the coordinates of the center of the circle
 			params.position = [ x, y ];
 			return this;
 		},
-		radius: function ( value ) {
+		radius: function ( value ) { 		// sets the radius of the circle in pixels
 			params.radius = value;
 			return this;
 		},
@@ -1041,7 +1041,7 @@ TG.Circle = function () {
 
 };
 
-TG.PutTexture = function ( texture ) {
+TG.PutTexture = function ( texture ) { 		// puts an already existing texture onto another one
 
 	var params = {
 		offset: [ 0, 0 ],
@@ -1050,11 +1050,11 @@ TG.PutTexture = function ( texture ) {
 	};
 
 	return new TG.Program( {
-		offset: function ( x, y ) {
+		offset: function ( x, y ) { 		// sets the coordinates of the top-leftmost point
 			params.offset = [ x, y ];
 			return this;
 		},
-		repeat: function ( value ) {
+		repeat: function ( value ) { 		// which algorithm should be used on coordinates outside of the texture; 1 = wrap around, 2 = wrap around but mirrored, 3 = extend the last pixel
 			params.repeat = value;
 			return this;
 		},
@@ -1099,7 +1099,7 @@ TG.PutTexture = function ( texture ) {
 
 };
 
-TG.RadialGradient = function () {
+TG.RadialGradient = function () { 		// generates a circular gradient around a point
 
 	var params = {
 		gradient: new TG.ColorInterpolator( TG.ColorInterpolatorMethod.LINEAR ),
@@ -1108,23 +1108,23 @@ TG.RadialGradient = function () {
 	};
 
 	return new TG.Program( {
-		repeat: function ( value ) {
+		repeat: function ( value ) { 		// sets how the gradient should repeat if outside of the range of the added points; 0 = clamp to the last point, 1 = wrap around, 2 = wrap around but mirrored
 			params.gradient.setRepeat( value );
 			return this;
 		},
-		radius: function ( value ) {
+		radius: function ( value ) { 		// sets how far from the center the last point (i.e. position 1) of the gradient is
 			params.radius = value;
 			return this;
 		},
-		interpolation: function ( value ) {
+		interpolation: function ( value ) { 		// sets the interpolation method of the gradient; 0 = step -> do not interpolate, 1 = linear-, 2 = spline-, 3 = cosine-interpolation
 			params.gradient.setInterpolation( value );
 			return this;
 		},
-		center: function ( x, y ) {
+		center: function ( x, y ) { 		// sets the center around which the gradient is generated
 			params.center = [ x, y ];
 			return this;
 		},
-		point: function ( position, r, g, b ) {
+		point: function ( position, r, g, b ) { 		// adds a point to the gradient; position 0 is the center and 1 is the radius
 			params.gradient.addPoint( position, r, g, b );
 			return this;
 		},
@@ -1143,22 +1143,22 @@ TG.RadialGradient = function () {
 
 };
 
-TG.LinearGradient = function () {
+TG.LinearGradient = function () { 		// generates a gradient across the whole texture
 
 	var params = {
 		gradient: new TG.ColorInterpolator( TG.ColorInterpolatorMethod.LINEAR )
 	};
 
 	return new TG.Program( {
-		repeat: function ( value ) {
+		repeat: function ( value ) { 		// sets how the gradient should repeat if outside of the range of the added points; 0 = clamp to the last point, 1 = wrap around, 2 = wrap around but mirrored
 			params.gradient.setRepeat( value );
 			return this;
 		},
-		interpolation: function ( value ) {
+		interpolation: function ( value ) { 		// sets the interpolation method of the gradient; 0 = step -> do not interpolate, 1 = linear-, 2 = spline-, 3 = cosine-interpolation
 			params.gradient.setInterpolation( value );
 			return this;
 		},
-		point: function ( position, r, g, b ) {
+		point: function ( position, r, g, b ) { 		// adds a point to the gradient; position 0 is x0 and 1 is the width of the texture
 			params.gradient.addPoint( position, r, g, b );
 			return this;
 		},
@@ -1178,7 +1178,7 @@ TG.LinearGradient = function () {
 
 // --- Filters ---
 
-TG.SineDistort = function () {
+TG.SineDistort = function () { 		// warps the texture in a wavy pattern
 
 	var params = {
 		sines: [ 4, 4 ],
@@ -1187,16 +1187,16 @@ TG.SineDistort = function () {
 	};
 
 	return new TG.Program( {
-		sines: function ( x, y ) {
+		sines: function ( x, y ) { 		// sets the width of the sine waves on the x and y axis respectively
 			if ( typeof y == "undefined" ) y = x;
 			params.sines = [ x, y ];
 			return this;
 		},
-		offset: function ( x, y ) {
+		offset: function ( x, y ) { 		// shifts the 'phase' of each wave
 			params.offset = [ x, y ];
 			return this;
 		},
-		amplitude: function ( x, y ) {
+		amplitude: function ( x, y ) { 		// sets the 'amplitude' of each wave (or intensity of the filter)
 			if ( typeof y == "undefined" ) y = x;
 			params.amplitude = [ x, y ];
 			return this;
@@ -1215,7 +1215,7 @@ TG.SineDistort = function () {
 
 };
 
-TG.Twirl = function () {
+TG.Twirl = function () { 		// distorts the texture into a vortex around a point
 
 	var params = {
 		strength: 0,
@@ -1224,15 +1224,15 @@ TG.Twirl = function () {
 	};
 
 	return new TG.Program( {
-		strength: function ( value ) {
+		strength: function ( value ) { 		// sets how much the texture should be rotated
 			params.strength = value / 100.0;
 			return this;
 		},
-		radius: function ( value ) {
+		radius: function ( value ) { 		// sets the radius of influence
 			params.radius = value;
 			return this;
 		},
-		position: function ( x, y ) {
+		position: function ( x, y ) { 		// sets the coordinates of the center of the swirl
 			params.position = [ x, y ];
 			return this;
 		},
@@ -1262,7 +1262,7 @@ TG.Twirl = function () {
 
 };
 
-TG.Transform = function () {
+TG.Transform = function () { 		// moves, rotates or scales the texture
 
 	var params = {
 		offset: [ 0, 0 ],
@@ -1271,15 +1271,15 @@ TG.Transform = function () {
 	};
 
 	return new TG.Program( {
-		offset: function ( x, y ) {
+		offset: function ( x, y ) { 		// moves the texture by 'x' and 'y' pixels
 			params.offset = [ -x, -y ];
 			return this;
 		},
-		angle: function ( value ) {
+		angle: function ( value ) { 		// rotates the texture by 'value' degrees around the origin (x: 0, y: 0)
 			params.angle = TG.Utils.deg2rad( value );
 			return this;
 		},
-		scale: function ( x, y ) {
+		scale: function ( x, y ) { 		// scales the texture by 'x' and 'y' (e.g. 2 doubles the size)
 			x = x || 1;
 			y = y || x;
 
@@ -1307,14 +1307,14 @@ TG.Transform = function () {
 
 };
 
-TG.Pixelate = function () {
+TG.Pixelate = function () { 		// divides the texture into 'pixels'
 
 	var params = {
 		size: [ 1, 1 ]
 	};
 
 	return new TG.Program( {
-		size: function ( x, y ) {
+		size: function ( x, y ) { 		// set the width and height of each 'pixel'
 			if ( typeof y == "undefined" ) y = x;
 			params.size = [ x, y ];
 			return this;
@@ -1334,22 +1334,22 @@ TG.Pixelate = function () {
 
 };
 
-TG.GradientMap = function () {
+TG.GradientMap = function () { 		// takes the value of each pixel and maps it to a color in a gradient; best used on a grayscale image
 
 	var params = {
 		gradient: new TG.ColorInterpolator( TG.ColorInterpolatorMethod.LINEAR )
 	};
 
 	return new TG.Program( {
-		repeat: function ( value ) {
+		repeat: function ( value ) { 		// how to map values that are out of range onto the gradient; 0 = clamp to the last (first) point of the gradient, 1 = wrap around, 2 = wrap around but mirrored
 			params.gradient.setRepeat( value );
 			return this;
 		},
-		interpolation: function ( value ) {
+		interpolation: function ( value ) { 		// set the interpolation method for the gradient; 0 = step -> do not interpolate, 1 = linear-, 2 = spline-, 3 = cosine-interpolation
 			params.gradient.setInterpolation( value );
 			return this;
 		},
-		point: function ( position, r, g, b ) {
+		point: function ( position, r, g, b ) { 		// add a point to the gradient; position 0 is black and 1 is white in the original texture
 			params.gradient.addPoint( position, r, g, b );
 			return this;
 		},
@@ -1370,9 +1370,10 @@ TG.GradientMap = function () {
 			].join('\n');
 		}
 	} );
+
 };
 
-TG.Normalize = function () {
+TG.Normalize = function () { 		// adjusts the whole texture so that every pixel is in the visible range (0 - 1)
 
 	return new TG.Program( {
 		getParams: function () {},
@@ -1404,14 +1405,14 @@ TG.Normalize = function () {
 
 };
 
-TG.Posterize = function () {
+TG.Posterize = function () { 		// reduces the amount of colors in a texture
 
 	var params = {
 		step: 2
 	};
 
 	return new TG.Program( {
-		step: function ( value ) {
+		step: function ( value ) { 		// sets how many possible values each color channel is divided into (2 means possible values are 0 and 1, 3 means 0, 0.5 and 1 etc.)
 			params.step = Math.max( value, 2 );
 			return this;
 		},

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -1271,38 +1271,38 @@ TG.Transform = function () {
 	};
 
 	return new TG.Program( {
-			offset: function ( x, y ) {
-				params.offset = [ x, y ];
-				return this;
-			},
-			angle: function ( value ) {
-				params.angle = TG.Utils.deg2rad( value );
-				return this;
-			},
-			scale: function ( x, y ) {
-				x = x || 1;
-				y = y || x;
+		offset: function ( x, y ) {
+			params.offset = [ x, y ];
+			return this;
+		},
+		angle: function ( value ) {
+			params.angle = TG.Utils.deg2rad( value );
+			return this;
+		},
+		scale: function ( x, y ) {
+			x = x || 1;
+			y = y || x;
 
-				params.scale = [ x, y ];
-				return this;
-			},
-			getParams: function () {
-				return params;
-			},
-			getSource: function () {
-				return [
-					'var x2 = x - width / 2;',
-					'var y2 = y - height / 2;',
+			params.scale = [ x, y ];
+			return this;
+		},
+		getParams: function () {
+			return params;
+		},
+		getSource: function () {
+			return [
+				'var x2 = x - width / 2;',
+				'var y2 = y - height / 2;',
 
-					'var s = x2 * ( Math.cos( params.angle ) / params.scale[ 0 ] ) + y2 * -( Math.sin( params.angle ) / params.scale[ 0 ] );',
-					'var t = x2 * ( Math.sin( params.angle ) / params.scale[ 1 ] ) + y2 *  ( Math.cos( params.angle ) / params.scale[ 1 ] );',
+				'var s = x2 * ( Math.cos( params.angle ) / params.scale[ 0 ] ) + y2 * -( Math.sin( params.angle ) / params.scale[ 0 ] );',
+				'var t = x2 * ( Math.sin( params.angle ) / params.scale[ 1 ] ) + y2 *  ( Math.cos( params.angle ) / params.scale[ 1 ] );',
 
-					's += params.offset[ 0 ] + width / 2;',
-					't += params.offset[ 1 ] + height / 2;',
+				's += params.offset[ 0 ] + width / 2;',
+				't += params.offset[ 1 ] + height / 2;',
 
-					'color.set( src.getPixelBilinear( s, t ) );',
-				].join( '\n' );
-			}
+				'color.set( src.getPixelBilinear( s, t ) );',
+			].join( '\n' );
+		}
 	} );
 
 };

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -8,6 +8,8 @@ var TG = {};
 
 TG.Utils = {
 
+	globalSeed: Date.now(), 		// used as a somewhat random seed, increased on each use so that each default seed is different
+
 	smoothStep: function ( edge0, edge1, x ) {
 
 		// Scale, bias and saturate x to 0..1 range
@@ -68,15 +70,15 @@ TG.Utils = {
 	},
 
 	hashRNG: function ( seed, x, y ) {
-		seed = ( Math.abs( seed % 2147483648 ) == 0 ) ? 1 : seed;
+		seed = Math.abs(seed % 0x7FFFFFFF) + 1;
 
-		var a = ( ( seed * ( x + 1 ) * 777 ) ^ ( seed * ( y + 1 ) * 123 ) ) % 2147483647;
+		var a = ( seed * ( ( x ^ seed * 777 ) || 556 ) * ( ( y ^ seed * 314 ) || 989 ) + seed * 123 ) % 0x7FFFFFFF;
 		a = (a ^ 61) ^ (a >> 16);
 		a = a + (a << 3);
 		a = a ^ (a >> 4);
 		a = a * 0x27d4eb2d;
 		a = a ^ (a >> 15);
-		a = a / 2147483647;
+		a = a / 0x7FFFFFFF;
 
 		return a;
 	},
@@ -572,7 +574,8 @@ TG.XOR = function () {
 TG.Noise = function () {
 
 	var params = {
-		seed: Date.now()
+		seed: TG.Utils.globalSeed++,
+		size: 1
 	};
 
 	return new TG.Program( {
@@ -580,12 +583,16 @@ TG.Noise = function () {
 			params.seed = value;
 			return this;
 		},
+		size: function ( value ) {
+			params.size = value;
+			return this;
+		},
 		getParams: function () {
 			return params;
 		},
 		getSource: function () {
 			return [
-				'var value = TG.Utils.hashRNG( params.seed, x, y );',
+				'var value = TG.Utils.hashRNG( params.seed, Math.floor( x / params.size ), Math.floor( y / params.size ) );',
 				'color[ 0 ] = value;',
 				'color[ 1 ] = value;',
 				'color[ 2 ] = value;'
@@ -599,7 +606,7 @@ TG.FractalNoise = function () {
 
 	var params = {
 		interpolator: new TG.ColorInterpolator( TG.ColorInterpolatorMethod.STEP ),
-		seed: Date.now(),
+		seed: TG.Utils.globalSeed++,
 		baseFrequency: 0.03125,
 		amplitude: 0.4,
 		persistence: 0.72,
@@ -699,7 +706,7 @@ TG.FractalNoise = function () {
 TG.CellularNoise = function () {
 
 	var params = {
-		seed: Date.now(),
+		seed: TG.Utils.globalSeed++,
 		density: 32,
 		weightRange: 0
 	};
@@ -739,7 +746,7 @@ TG.CellularNoise = function () {
 TG.VoronoiNoise = function () {
 
 	var params = {
-		seed: Date.now(),
+		seed: TG.Utils.globalSeed++,
 		density: 32,
 		weightRange: 0
 	};
@@ -776,7 +783,7 @@ TG.VoronoiNoise = function () {
 TG.CellularFractal = function () {
 
 	var params = {
-		seed: Date.now(),
+		seed: TG.Utils.globalSeed++,
 		weightRange: 0,
 		baseDensity: 64,
 		amplitude: 0.7,
@@ -847,7 +854,7 @@ TG.CellularFractal = function () {
 TG.VoronoiFractal = function () {
 
 	var params = {
-		seed: Date.now(),
+		seed: TG.Utils.globalSeed++,
 		weightRange: 0,
 		baseDensity: 64,
 		amplitude: 0.6,

--- a/src/TexGen.js
+++ b/src/TexGen.js
@@ -152,9 +152,14 @@ TG.ColorInterpolator.prototype = {
 
 	},
 
-	addPoint: function ( position, color ) {
+	addPoint: function ( position, r, g, b ) {
+		if ( Array.isArray( r ) ) {
+			b = r[ 2 ]; g = r[ 1 ]; r = r[ 0 ];
+		}
+		if ( typeof g == 'undefined' ) g = r;
+		if ( typeof b == 'undefined' ) b = r;
 
-		this.points.push( { pos: position, color: color } );
+		this.points.push( { pos: position, color: [ r, g, b ] } );
 		this.points.sort( function( a, b ) {
 			return a.pos - b.pos;
 		});
@@ -458,8 +463,8 @@ TG.Program = function ( object ) {
 
 	object.tint = function ( r, g, b ) {
 		tint[ 0 ] = r;
-		tint[ 1 ] = g;
-		tint[ 2 ] = b;
+		tint[ 1 ] = ( typeof g == 'undefined' ) ? r : g;
+		tint[ 2 ] = ( typeof b == 'undefined' ) ? r : b;
 		return this;
 	};
 
@@ -940,6 +945,7 @@ TG.CheckerBoard = function () {
 
 	return new TG.Program( {
 		size: function ( x, y ) {
+			if ( typeof y == "undefined" ) y = x;
 			params.size = [ x, y ];
 			return this;
 		},
@@ -979,6 +985,7 @@ TG.Rect = function () {
 			return this;
 		},
 		size: function ( x, y ) {
+			if ( typeof y == "undefined" ) y = x;
 			params.size = [ x, y ];
 			return this;
 		},
@@ -1117,8 +1124,8 @@ TG.RadialGradient = function () {
 			params.center = [ x, y ];
 			return this;
 		},
-		point: function ( position, color ) {
-			params.gradient.addPoint( position, color );
+		point: function ( position, r, g, b ) {
+			params.gradient.addPoint( position, r, g, b );
 			return this;
 		},
 		getParams: function () {
@@ -1151,8 +1158,8 @@ TG.LinearGradient = function () {
 			params.gradient.setInterpolation( value );
 			return this;
 		},
-		point: function ( position, color ) {
-			params.gradient.addPoint( position, color );
+		point: function ( position, r, g, b ) {
+			params.gradient.addPoint( position, r, g, b );
 			return this;
 		},
 		getParams: function () {
@@ -1181,6 +1188,7 @@ TG.SineDistort = function () {
 
 	return new TG.Program( {
 		sines: function ( x, y ) {
+			if ( typeof y == "undefined" ) y = x;
 			params.sines = [ x, y ];
 			return this;
 		},
@@ -1189,6 +1197,7 @@ TG.SineDistort = function () {
 			return this;
 		},
 		amplitude: function ( x, y ) {
+			if ( typeof y == "undefined" ) y = x;
 			params.amplitude = [ x, y ];
 			return this;
 		},
@@ -1271,7 +1280,9 @@ TG.Transform = function () {
 				return this;
 			},
 			scale: function ( x, y ) {
-				if ( x === 0 || y === 0 ) return;
+				x = x || 1;
+				y = y || x;
+
 				params.scale = [ x, y ];
 				return this;
 			},
@@ -1304,6 +1315,7 @@ TG.Pixelate = function () {
 
 	return new TG.Program( {
 		size: function ( x, y ) {
+			if ( typeof y == "undefined" ) y = x;
 			params.size = [ x, y ];
 			return this;
 		},
@@ -1337,8 +1349,8 @@ TG.GradientMap = function () {
 			params.gradient.setInterpolation( value );
 			return this;
 		},
-		point: function ( position, color ) {
-			params.gradient.addPoint( position, color );
+		point: function ( position, r, g, b ) {
+			params.gradient.addPoint( position, r, g, b );
 			return this;
 		},
 		getParams: function () {


### PR DESCRIPTION
### Changes: 
- Rearranged some of the code into a more logical order.
- Added a .pow() operation using Math.pow(x, y). Useful for increasing or decreasing contrast.
- Added a globalSeed variable that gets incremented on each use to avoid 'seed collisions' in cases where there's less than 1ms between calls.
- Added a size-parameter to TG.Noise that increases the 'grid' of the noise (makes it more 'pixel-y').
- Added the posibility to 'initialize' a filter. Simply, code that gets run shortly before the main loop.
- Simplified TG.Posterize, since I over-engineered it a bit.
- Added the cosine interpolation method.
- Allowing to input rgb-values individually to .point()-functions for gradients on top of arrays.
- Copy some arguments for convenience, e.g. .tint(0.5) sets r, g *and* b.
- Removed extra indentation inside TG.Transform.
- Rename TG.Number to TG.Fill like discussed (#30).
- Reversed some 'offset'-parameters to make them more intuitive, so that a positive offset moves the texture to the right for example.
- Made TG.SinX and TG.SinY frequency relative to pixels, meaning setting frequency to, for example, 20 means the sine wave will be 20 pixels wide.
- Added a comment to every generator and parameter explaining what they do (maybe resolves #33?).
- Some changes to the examples page including adding CodeMirror syntax-highlighting

The renaming of TG.Number, reversing offsets and making frequency relative to pixels breaks older stuff of course, but I made sure that the examples still work.

If something doesn't seem right, feel free to tell me!